### PR TITLE
change target branch in documentation repo to gh-pages for deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
               cp -r _site/* documentation
               cd documentation
               git add .
-              git commit -m "deploying https://github.com/plotly/graphing-libraries-docs/commit/${CIRCLE_SHA1}"
+              git commit -m "deploying https://github.com/plotly/graphing-library-docs/commit/${CIRCLE_SHA1}"
               git push
               cd ..
               rm -rf documentation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,8 @@ jobs:
             rm -f snapshots/*/*/*.bkp
             percy snapshot snapshots --enable_javascript
             rm -rf 'snapshots/'
-            if [ "${CIRCLE_BRANCH}" == "test-gld-ci-setup" ]; then
-              git clone --depth=1 --branch=test-gld-ci-setup https://github.com/plotly/documentation.git
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              git clone --depth=1 --branch=gh-pages https://github.com/plotly/documentation.git
               git config user.name plotlydocbot
               git config user.email accounts@plot.ly
               cp -r _site/* documentation


### PR DESCRIPTION
The purpose of this PR is to transition from using the `documentation` repo to using this one to deploy changes to the `gh-pages` branch of the documentation repo. 