### PR TITLE
fix JavaScript syntax error caused by U+2019 instead of apostrophe

### DIFF
--- a/_posts/plotly_js/basic/bar/2015-08-07-barchart-direct-labels.html
+++ b/_posts/plotly_js/basic/bar/2015-08-07-barchart-direct-labels.html
@@ -32,7 +32,7 @@ var data = [trace1];
 
 var layout = {
   title: 'January 2013 Sales Report',
-  barmode: 'stack’
+  barmode: 'stack'
 };
 
 Plotly.newPlot('myDiv', data, layout);

--- a/_posts/plotly_js/basic/bar/2018-02-27-bar-base.html
+++ b/_posts/plotly_js/basic/bar/2018-02-27-bar-base.html
@@ -13,7 +13,7 @@ var data = [
     x: ['2016','2017','2018'],
     y: [500,600,700],
     base: [-500,-600,-700],
-    hovertemplate: '%{base}'
+    hovertemplate: '%{base}',
     marker: {
       color: 'red'
     },


### PR DESCRIPTION
Noticed that this example did not work properly on CodePen.  Did
a hex dump and noticed that string was terminated by UTF-encoded
right single quotation mark (U+2019) rather than a standard
apostrophe (U+0027).