### PR TITLE
make sure links to reference page in search modal don't 404

### DIFF
--- a/all_static/javascripts/algolia/algolia.js
+++ b/all_static/javascripts/algolia/algolia.js
@@ -55,6 +55,9 @@ $(function(config) {
         },
         transformData: {
           item: function(hit) {
+            if (hit.permalink.includes("reference")){
+              hit.permalink = lang + '/' + hit.permalink;
+            }
             hit.raw = JSON.stringify(hit, null, 2);
             return hit;
           }


### PR DESCRIPTION
The purpose of this PR is to make sure hyperlinks to the reference pages in the search modal do not result in a 404 page. 

This is happening because the `permalink` attribute does not include the language. Therefore it is necessary to insert the language into the permalink as the result is returned from algolia. 