### PR TITLE
add build timestamp

### DIFF
--- a/_includes/layouts/head.html
+++ b/_includes/layouts/head.html
@@ -1,4 +1,6 @@
 <head>
+      <!-- This page was last built at {{ "now" | date: "%Y-%m-%d %H:%M" }} -->
+
       <meta charset="utf-8"/>
 
       <!-- Media query magic - http://stackoverflow.com/questions/19945658/my-iphone-thinks-its-980px-wide -->


### PR DESCRIPTION
The purpose of this PR is to add a build timestamp as an html comment to the `head` element of every page. 

This will make it easier to keep track of which version of the site is in production.