### PR TITLE
remove moment.js

### DIFF
--- a/_includes/layouts/_footer-main.html
+++ b/_includes/layouts/_footer-main.html
@@ -158,7 +158,6 @@
 </script>
 <script id="algolia__template--no-results" type="text/template">No results found.</script>
 <script src="//cdn.jsdelivr.net/hogan.js/3.0.2/hogan.min.js"></script>
-<script src="//cdn.jsdelivr.net/momentjs/2.10.3/moment.min.js"></script>
 <script src="/all_static/javascripts/algolia/algolia.js"></script>
 {% endif %}
  <!-- Hash offset Script -->


### PR DESCRIPTION
closes https://github.com/plotly/graphing-library-docs/issues/26

It turns out that `moment.js` uses an anonymous define, which `require.js` does not like. Since there are no references to `moment()` in the repo, should be safe to delete the script. 

Prod:
![Screen Shot 2020-03-17 at 2 12 19 PM](https://user-images.githubusercontent.com/1557650/76887943-6a1ec180-6859-11ea-9a89-b919fd28fedd.png)

This branch:
![Screen Shot 2020-03-17 at 2 12 32 PM](https://user-images.githubusercontent.com/1557650/76887959-6f7c0c00-6859-11ea-8ba1-08936aad80ef.png)
