### PR TITLE
make sure text does not overflow window

### DIFF
--- a/all_static/css/main.css
+++ b/all_static/css/main.css
@@ -2895,7 +2895,6 @@ html body .rendered_html div.icon.copy {
   display: block;
   background: #f3f3f3;
   font-family: "campaign", sans-serif;
-  width: 610px;
   padding: 15px 15px 15px 15px;
   text-align: justify;
   text-justify: inter-word; }
@@ -5589,6 +5588,7 @@ div.cell.selected {
 
 div.inner_cell {
   display: -webkit-box;
+  max-width: 100%;
   -webkit-box-orient: vertical;
   -webkit-box-align: stretch;
   display: -moz-box;


### PR DESCRIPTION
The purpose of this PR is to make sure that text does not overflow the window on mobile. 

![Screen Shot 2020-04-06 at 7 24 26 PM](https://user-images.githubusercontent.com/1557650/78614331-450be600-783c-11ea-9584-248f834267ba.png)
