### PR TITLE
make sure sidebar font is 14px across languages

### DIFF
--- a/all_static/css/main.css
+++ b/all_static/css/main.css
@@ -1708,7 +1708,6 @@ aside.\--sidebar-container {
         display: inline-block;
         width: 100%;
         text-decoration: none;
-        font-size: 1rem;
         }
         aside.\--sidebar-container .\--sidebar-body ul li a::before {
           display: none !important; }


### PR DESCRIPTION
addresses https://github.com/plotly/marketing-website/issues/313

For Windows users, the current `font-size` of `1rem` causes display issues as different letters render at different heights. 

Removing the style which introduces rem units forces the sidebar element to default to using the `body` font-size of `14px` across all languages. 

This was tested by running the `bundle exec rake serve` command and using the Chrome inspector to make sure that the font-size of the sidebar anchors across all languages are 14px.  

Screenshots:

![Screen Shot 2020-04-09 at 12 23 30 PM](https://user-images.githubusercontent.com/1557650/78917819-6c8dc900-7a5d-11ea-9d30-b73b6680015c.png)
![Screen Shot 2020-04-09 at 12 23 14 PM](https://user-images.githubusercontent.com/1557650/78917821-6d265f80-7a5d-11ea-865d-e6a8f859872f.png)
![Screen Shot 2020-04-09 at 12 22 57 PM](https://user-images.githubusercontent.com/1557650/78917822-6dbef600-7a5d-11ea-8dac-2101127df99a.png)
