### PR TITLE
add github stars to header

### DIFF
--- a/_includes/layouts/_header-main.html
+++ b/_includes/layouts/_header-main.html
@@ -40,6 +40,14 @@
             <div class="--wrap-right">
                 <nav class="--nav-meta" role="navigation">
                     <ul>
+                        {% if page.permalink contains "python/" %}
+                        <iframe style="padding-top: 5px;" src="https://ghbtns.com/github-btn.html?user=plotly&repo=plotly.py&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="40px"></iframe>
+{% elsif page.permalink contains "javascript/" %}
+<iframe src="https://ghbtns.com/github-btn.html?user=plotly&repo=plotly.js&type=star&count=true&size=large" style="padding-top: 5px;" frameborder="0" scrolling="0" width="160px" height="40px"></iframe>
+{% elsif page.permalink contains "r/" or page.permalink contains "ggplot2/" %}
+<iframe src="https://ghbtns.com/github-btn.html?user=ropensci&repo=plotly&type=star&count=true&size=large" style="padding-top: 5px;" frameborder="0" scrolling="0" width="160px" height="40px"></iframe>
+  {% endif %}
+                        
                         <li><a href="https://plotly.com/get-demo/" data-mode="1" target="_blank" class="typeform-share button --enterprise-quaternary">DEMO DASH</a></li>
                     </ul>
                 </nav>


### PR DESCRIPTION
The purpose of this PR is to add a github stars button to pages beyond just the index page, on a per-language basis. The github button disappears at the same breakpoint as the `demo dash` button.

Screenshots:

![Screen Shot 2020-04-17 at 3 03 06 PM](https://user-images.githubusercontent.com/1557650/79605197-75197b80-80bd-11ea-8c6d-3b74d845f282.png)
![Screen Shot 2020-04-17 at 3 03 12 PM](https://user-images.githubusercontent.com/1557650/79605199-75b21200-80bd-11ea-9852-146e1c906903.png)
![Screen Shot 2020-04-17 at 3 03 20 PM](https://user-images.githubusercontent.com/1557650/79605200-75b21200-80bd-11ea-8770-7f8e3be17ad1.png)
![Screen Shot 2020-04-17 at 3 03 24 PM](https://user-images.githubusercontent.com/1557650/79605201-75b21200-80bd-11ea-87bc-ccd81a4c2467.png)
![Screen Shot 2020-04-17 at 3 03 43 PM](https://user-images.githubusercontent.com/1557650/79605202-764aa880-80bd-11ea-908a-acf054c941b9.png)
![Screen Shot 2020-04-17 at 3 03 46 PM](https://user-images.githubusercontent.com/1557650/79605203-764aa880-80bd-11ea-8ba6-63c79ace7275.png)
![Screen Shot 2020-04-17 at 3 03 51 PM](https://user-images.githubusercontent.com/1557650/79605205-76e33f00-80bd-11ea-9a1a-56c419014432.png)
![Screen Shot 2020-04-17 at 3 03 56 PM](https://user-images.githubusercontent.com/1557650/79605206-76e33f00-80bd-11ea-8547-37a3b6af2940.png)

