### PR TITLE
refactor language index and subindex grid layout

### DIFF
--- a/_includes/layouts/grid-item.html
+++ b/_includes/layouts/grid-item.html
@@ -1,0 +1,10 @@
+<li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
+    <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+        <div class="--item-meta"><span>{{page.name}}</span></div>
+        <div class="--item-image">
+            <span>View Tutorial</span>
+            <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
+        </div>
+    </a>
+
+</li>

--- a/_includes/posts/documentation_eg.html
+++ b/_includes/posts/documentation_eg.html
@@ -87,8 +87,13 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-            {%- for page in languagelist -%}
-            {% if page.display_as == "file_settings" %}
+
+            {% unless page.display_as == "file_settings" %}
+
+            {% for page in languagelist %}
+            {% if page.display_as == "file_settings" and page.order < 6 %}
+
+
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -103,7 +108,34 @@
             </li>
 
             {% endif %}
-            {%- endfor -%}
+            {% endfor %}
+
+            {% endunless %}
+
+            {% if page.display_as == "file_settings" %}
+
+
+            
+            {% for page in languagelist %}
+            {% if page.display_as == "file_settings" %}
+
+
+
+            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
+                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                    <div class="--item-meta"><span>{{page.name}}</span></div>
+                    <div class="--item-image">
+                        <span>View Tutorial</span>
+                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
+                    </div>
+                </a>
+
+            </li>
+
+            {% endif %}
+            {% endfor %}
+
+            {% endif %}
         </ul>
     </section>
 </section>

--- a/_includes/posts/documentation_eg.html
+++ b/_includes/posts/documentation_eg.html
@@ -1,3 +1,9 @@
+{% assign languageindexpage = false %}
+
+{% if page.display_as %}
+{% assign languageindexpage = true %}
+{% endif %}
+
 {% comment %}First, check which sections this page should contain checking all of the posts{% endcomment %}
 {%- for page in languagelist -%}
 {% if page.display_as == "file_settings" %}
@@ -87,13 +93,8 @@
     </header>
     <section class="--grid">
         <ul class="--grid-list">
-
-            {% unless page.display_as == "file_settings" %}
-
-            {% for page in languagelist %}
-            {% if page.display_as == "file_settings" and page.order < 6 %}
-
-
+            {%- for page in languagelist -%}
+            {% if page.display_as == "file_settings" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -108,34 +109,7 @@
             </li>
 
             {% endif %}
-            {% endfor %}
-
-            {% endunless %}
-
-            {% if page.display_as == "file_settings" %}
-
-
-            
-            {% for page in languagelist %}
-            {% if page.display_as == "file_settings" %}
-
-
-
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
-
-            {% endif %}
-            {% endfor %}
-
-            {% endif %}
+            {%- endfor -%}
         </ul>
     </section>
 </section>
@@ -148,7 +122,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_type" or page.display_as == "basic" %}
+            {% if page.display_as == "chart_type" or page.display_as == "basic" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -176,7 +150,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "statistical" %}
+            {% if page.display_as == "statistical" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -206,7 +180,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "scientific" %}
+            {% if page.display_as == "scientific" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -236,7 +210,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "financial" %}
+            {% if page.display_as == "financial" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -266,7 +240,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "maps" %}
+            {% if page.display_as == "maps" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -296,7 +270,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "3d_charts" %}
+            {% if page.display_as == "3d_charts" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -326,7 +300,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "multiple_axes" %}
+            {% if page.display_as == "multiple_axes" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -356,7 +330,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -386,7 +360,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -416,7 +390,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -446,7 +420,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "transforms" %}
+            {% if page.display_as == "transforms" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -474,7 +448,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "controls" %}
+            {% if page.display_as == "controls" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -504,7 +478,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "animations" %}
+            {% if page.display_as == "animations" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -534,7 +508,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_studio" %}
+            {% if page.display_as == "chart_studio" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -562,7 +536,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "financial_analysis" %}
+            {% if page.display_as == "financial_analysis" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -595,7 +569,7 @@
 
 {% assign counter=0 %}
 {%- for page in languagelist -%}
-{% if page.display_as == "layout_opt" %}
+{% if page.display_as == "layout_opt" and page.order < 6 or languageindexpage %}
 {% if counter == 6 %}</ul></div><div class="six columns"><ul>{% endif %}
 <li><a class="no-list-style" href="/{{page.permalink}}">{{page.name}}</a></li>
 {% assign counter=counter | plus:1 %}
@@ -614,7 +588,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "advanced_opt" %}
+            {% if page.display_as == "advanced_opt" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -637,7 +611,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "style_opt" %}
+            {% if page.display_as == "style_opt" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -660,7 +634,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "layout_opt" %}
+            {% if page.display_as == "layout_opt" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -683,7 +657,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "legacy_charts" %}
+            {% if page.display_as == "legacy_charts" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -706,7 +680,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "databases" %}
+            {% if page.display_as == "databases" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -730,7 +704,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "report_generation" %}
+            {% if page.display_as == "report_generation" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -758,7 +732,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -782,7 +756,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "tutorial" %}
+            {% if page.display_as == "tutorial" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -805,7 +779,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "get_request" %}
+            {% if page.display_as == "get_request" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -828,7 +802,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "mathematics" %}
+            {% if page.display_as == "mathematics" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -852,7 +826,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "statistics" %}
+            {% if page.display_as == "statistics" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -875,7 +849,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "peak-analysis" %}
+            {% if page.display_as == "peak-analysis" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -898,7 +872,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "signal-analysis" %}
+            {% if page.display_as == "signal-analysis" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -923,7 +897,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "aesthetics" %}
+            {% if page.display_as == "aesthetics" and page.order < 6 or languageindexpage %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
                     <div class="--item-meta"><span>{{page.name}}</span></div>
@@ -951,7 +925,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "geoms" %}
+            {% if page.display_as == "geoms" and page.order < 6 or languageindexpage %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
                     <div class="--item-meta"><span>{{page.name}}</span></div>
@@ -978,7 +952,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "faceting" %}
+            {% if page.display_as == "faceting" and page.order < 6 or languageindexpage %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
                     <div class="--item-meta"><span>{{page.name}}</span></div>
@@ -1005,7 +979,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "other" %}
+            {% if page.display_as == "other" and page.order < 6 or languageindexpage %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
                     <div class="--item-meta"><span>{{page.name}}</span></div>
@@ -1034,7 +1008,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "theme" %}
+            {% if page.display_as == "theme" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">

--- a/_includes/posts/documentation_eg.html
+++ b/_includes/posts/documentation_eg.html
@@ -90,17 +90,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "file_settings" %}
 
-
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
+            {% include layouts/grid-item.html %}
+            
 
             {% endif %}
             {%- endfor -%}
@@ -119,16 +110,8 @@
             {% if page.display_as == "chart_type" or page.display_as == "basic" %}
 
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -146,19 +129,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "statistical" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -176,19 +148,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "scientific" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -206,19 +167,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "financial" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -236,19 +186,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "maps" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -266,19 +205,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "3d_charts" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -296,19 +224,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "multiple_axes" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -326,19 +243,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -356,19 +262,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -386,19 +281,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -417,16 +301,8 @@
             {% if page.display_as == "transforms" %}
 
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -444,19 +320,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "controls" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -474,19 +339,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "animations" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -505,16 +359,8 @@
             {% if page.display_as == "chart_studio" %}
 
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -532,19 +378,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "financial_analysis" %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+                        {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -892,16 +727,8 @@
         <ul class="--grid-list">
             {%- for page in languagelist -%}
             {% if page.display_as == "aesthetics" %}
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -920,16 +747,8 @@
         <ul class="--grid-list">
             {%- for page in languagelist -%}
             {% if page.display_as == "geoms" %}
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -947,16 +766,8 @@
         <ul class="--grid-list">
             {%- for page in languagelist -%}
             {% if page.display_as == "faceting" %}
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -974,16 +785,8 @@
         <ul class="--grid-list">
             {%- for page in languagelist -%}
             {% if page.display_as == "other" %}
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -1005,16 +808,8 @@
             {% if page.display_as == "theme" %}
 
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -1,3 +1,15 @@
+{% assign languageindexpage = false %}
+
+{% if page.display_as %}
+{% assign languageindexpage = true %}
+{% endif %}
+
+{% assign mainlanguage = false %}
+
+{% if page.language == "plotly_js" or page.language == "python" or page.language == "r" %}
+{% assign mainlanguage = true %}
+{% endif %}
+
 {% comment %}First, check which sections this page should contain checking all of the posts{% endcomment %}
 {%- for page in languagelist -%}
 {% if page.display_as == "file_settings" %}
@@ -88,7 +100,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "file_settings" %}
+            {% if page.language == "plotly_js" and page.display_as == "file_settings" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -116,7 +128,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_type" or page.display_as == "basic" %}
+            {% if page.display_as == "chart_type" or page.display_as == "basic" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -144,7 +156,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "statistical" %}
+            {% if page.display_as == "statistical" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -174,7 +186,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "scientific" %}
+            {% if page.display_as == "scientific" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -204,7 +216,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "financial" %}
+            {% if page.display_as == "financial" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -234,7 +246,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "maps" %}
+            {% if page.display_as == "maps" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -264,7 +276,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "3d_charts" %}
+            {% if page.display_as == "3d_charts" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -294,7 +306,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "multiple_axes" %}
+            {% if page.display_as == "multiple_axes" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -324,7 +336,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -354,7 +366,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -384,7 +396,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -414,7 +426,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "transforms" %}
+            {% if page.display_as == "transforms" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -442,7 +454,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "controls" %}
+            {% if page.display_as == "controls" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -472,7 +484,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "animations" %}
+            {% if page.display_as == "animations" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -502,7 +514,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_studio" %}
+            {% if page.display_as == "chart_studio" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
@@ -530,7 +542,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "financial_analysis" %}
+            {% if page.display_as == "financial_analysis" and page.order < 6 or languageindexpage %}
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -563,7 +575,7 @@
 
 {% assign counter=0 %}
 {%- for page in languagelist -%}
-{% if page.display_as == "layout_opt" %}
+{% if page.display_as == "layout_opt" and page.order < 6 or languageindexpage %}
 {% if counter == 6 %}</ul></div><div class="six columns"><ul>{% endif %}
 <li><a class="no-list-style" href="/{{page.permalink}}">{{page.name}}</a></li>
 {% assign counter=counter | plus:1 %}
@@ -582,7 +594,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "advanced_opt" %}
+            {% if page.display_as == "advanced_opt" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -605,7 +617,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "style_opt" %}
+            {% if page.display_as == "style_opt" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -628,7 +640,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "layout_opt" %}
+            {% if page.display_as == "layout_opt" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -651,7 +663,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "legacy_charts" %}
+            {% if page.display_as == "legacy_charts" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -674,7 +686,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "databases" %}
+            {% if page.display_as == "databases" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -698,7 +710,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "report_generation" %}
+            {% if page.display_as == "report_generation" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -726,7 +738,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -750,7 +762,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "tutorial" %}
+            {% if page.display_as == "tutorial" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -773,7 +785,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "get_request" %}
+            {% if page.display_as == "get_request" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -796,7 +808,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "mathematics" %}
+            {% if page.display_as == "mathematics" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -820,7 +832,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "statistics" %}
+            {% if page.display_as == "statistics" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -843,7 +855,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "peak-analysis" %}
+            {% if page.display_as == "peak-analysis" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -866,7 +878,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "signal-analysis" %}
+            {% if page.display_as == "signal-analysis" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -891,7 +903,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "aesthetics" %}
+            {% if page.display_as == "aesthetics" and page.order < 6 or languageindexpage %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
                     <div class="--item-meta"><span>{{page.name}}</span></div>
@@ -919,7 +931,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "geoms" %}
+            {% if page.display_as == "geoms" and page.order < 6 or languageindexpage %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
                     <div class="--item-meta"><span>{{page.name}}</span></div>
@@ -946,7 +958,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "faceting" %}
+            {% if page.display_as == "faceting" and page.order < 6 or languageindexpage %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
                     <div class="--item-meta"><span>{{page.name}}</span></div>
@@ -973,7 +985,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "other" %}
+            {% if page.display_as == "other" and page.order < 6 or languageindexpage %}
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
                     <div class="--item-meta"><span>{{page.name}}</span></div>
@@ -1002,7 +1014,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "theme" %}
+            {% if page.display_as == "theme" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -45,18 +45,6 @@
 {% elsif page.display_as == "advanced_opt" %}
 {% assign advanced_opt = true %}
 
-<!-- START OF GGPLOT CUSTOM LAYOUT -->
-{% elsif page.display_as == "aesthetics" %}
-{% assign aesthetics = true %}
-{% elsif page.display_as == "geoms" %}
-{% assign geoms = true %}
-{% elsif page.display_as == "faceting" %}
-{% assign faceting = true %}
-{% elsif page.display_as == "other" %}
-{% assign other = true %}
-{% elsif page.display_as == "theme" %}
-{% assign theme = true %}
-<!-- END OF GGPLOT CUSTOM LAYOUT -->
 {% endif %}
 {%- endfor -%}
 
@@ -103,16 +91,8 @@
             {% if page.display_as == "file_settings" and page.order < 6 or languageindexpage %}
 
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+            {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -131,16 +111,8 @@
             {% if page.display_as == "chart_type" or page.display_as == "basic" and page.order < 6 or languageindexpage %}
 
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+            {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -158,19 +130,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "statistical" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -188,19 +149,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "scientific" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -218,19 +168,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "financial" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -248,19 +187,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "maps" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -278,19 +206,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "3d_charts" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -308,19 +225,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "multiple_axes" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -338,19 +244,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -368,19 +263,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -398,19 +282,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -429,16 +302,8 @@
             {% if page.display_as == "transforms" and page.order < 6 or languageindexpage %}
 
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -456,19 +321,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "controls" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -486,19 +340,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "animations" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -517,16 +360,8 @@
             {% if page.display_as == "chart_studio" and page.order < 6 or languageindexpage %}
 
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -544,19 +379,8 @@
             {%- for page in languagelist -%}
             {% if page.display_as == "financial_analysis" and page.order < 6 or languageindexpage %}
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+            {% include layouts/grid-item.html %}
 
-
-                    <!--<a href="{{page.permalink}}">-->
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
-
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -904,16 +728,8 @@
         <ul class="--grid-list">
             {%- for page in languagelist -%}
             {% if page.display_as == "aesthetics" and page.order < 6 or languageindexpage %}
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -932,16 +748,8 @@
         <ul class="--grid-list">
             {%- for page in languagelist -%}
             {% if page.display_as == "geoms" and page.order < 6 or languageindexpage %}
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -959,16 +767,8 @@
         <ul class="--grid-list">
             {%- for page in languagelist -%}
             {% if page.display_as == "faceting" and page.order < 6 or languageindexpage %}
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -986,16 +786,8 @@
         <ul class="--grid-list">
             {%- for page in languagelist -%}
             {% if page.display_as == "other" and page.order < 6 or languageindexpage %}
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}
@@ -1017,16 +809,8 @@
             {% if page.display_as == "theme" and page.order < 6 or languageindexpage %}
 
 
-            <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                    <div class="--item-image">
-                        <span>View Tutorial</span>
-                        <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
-                    </div>
-                </a>
+                        {% include layouts/grid-item.html %}
 
-            </li>
 
             {% endif %}
             {%- endfor -%}

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -100,7 +100,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.language == "plotly_js" and page.display_as == "file_settings" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "file_settings" and page.order < 6 or languageindexpage %}
 
 
             <li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">

--- a/_posts/ggplot2/2016-12-16-ggplot2-index.md
+++ b/_posts/ggplot2/2016-12-16-ggplot2-index.md
@@ -21,6 +21,6 @@ redirect_from: ggplot2/reference/
   </div>
 </header>
 
-{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","ggplot2"  | sort: "order"  %}
+{% assign languagelist = site.posts | where:"language","ggplot2"  | sort: "order"  %}
 
 {% include posts/documentation_eg.html %}

--- a/_posts/ggplot2/2016-12-16-ggplot2-index.md
+++ b/_posts/ggplot2/2016-12-16-ggplot2-index.md
@@ -4,7 +4,6 @@ name: ggplot2 Graphing Library
 description: With ggplotly() by Plotly, you can convert your ggplot2 figures into interactive ones powered by plotly.js, ready for embedding into Dash applications.
 layout: langindex
 language: ggplot2
-display_as: false
 redirect_from: ggplot2/reference/
 ---
 
@@ -21,6 +20,6 @@ redirect_from: ggplot2/reference/
   </div>
 </header>
 
-{% assign languagelist = site.posts | where:"language","ggplot2"  | sort: "order"  %}
+{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","ggplot2" | sort: "order" %}
 
 {% include posts/documentation_eg.html %}

--- a/_posts/ggplot2/2016-12-16-ggplot2-index.md
+++ b/_posts/ggplot2/2016-12-16-ggplot2-index.md
@@ -4,6 +4,7 @@ name: ggplot2 Graphing Library
 description: With ggplotly() by Plotly, you can convert your ggplot2 figures into interactive ones powered by plotly.js, ready for embedding into Dash applications.
 layout: langindex
 language: ggplot2
+display_as: false
 redirect_from: ggplot2/reference/
 ---
 

--- a/_posts/julia/2015-04-05-julia-index.html
+++ b/_posts/julia/2015-04-05-julia-index.html
@@ -4,6 +4,7 @@ permalink: /julia/
 description: Plotly's Julia graphing library makes interactive, publication-quality graphs online. Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.
 layout: langindex
 language: julia
+display_as: false
 redirect_from: julia/reference/
 ---
 

--- a/_posts/julia/2015-04-05-julia-index.html
+++ b/_posts/julia/2015-04-05-julia-index.html
@@ -27,6 +27,6 @@ redirect_from: julia/reference/
 </header>
 
 	<h2>Documentation Examples</h2>
-		{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","julia" | sort: "order" %}
+		{% assign languagelist = site.posts | where:"language","julia" | sort: "order" %}
 
 		{% include posts/documentation_eg.html %}

--- a/_posts/julia/2015-04-05-julia-index.html
+++ b/_posts/julia/2015-04-05-julia-index.html
@@ -27,6 +27,6 @@ redirect_from: julia/reference/
 </header>
 
 	<h2>Documentation Examples</h2>
-		{% assign languagelist = site.posts | where:"language","julia" | sort: "order" %}
+	{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","julia" | sort: "order" %}
 
 		{% include posts/documentation_eg.html %}

--- a/_posts/matlab/2015-04-05-matlab-index.html
+++ b/_posts/matlab/2015-04-05-matlab-index.html
@@ -4,6 +4,7 @@ permalink: /matlab/
 description: Create interactive charts in your web browser with MATLAB<sup>&reg;</sup> and Plotly.
 layout: langindex
 language: matlab
+display_as: false
 ---
 
 

--- a/_posts/matlab/2015-04-05-matlab-index.html
+++ b/_posts/matlab/2015-04-05-matlab-index.html
@@ -90,6 +90,6 @@ fig2plotly(gcf, 'offline', true);</code></pre>
 	<br>
 
 	<h2>Documentation Examples</h2>
-		{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","matlab"  | sort: "order" %}
+		{% assign languagelist = site.posts | where:"language","matlab"  | sort: "order" %}
 
 		{% include posts/documentation_eg.html %}

--- a/_posts/matlab/2015-04-05-matlab-index.html
+++ b/_posts/matlab/2015-04-05-matlab-index.html
@@ -90,6 +90,6 @@ fig2plotly(gcf, 'offline', true);</code></pre>
 	<br>
 
 	<h2>Documentation Examples</h2>
-		{% assign languagelist = site.posts | where:"language","matlab"  | sort: "order" %}
+	{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","matlab"  | sort: "order" %}
 
 		{% include posts/documentation_eg.html %}

--- a/_posts/nodejs/2015-04-05-node_js-index.html
+++ b/_posts/nodejs/2015-04-05-node_js-index.html
@@ -22,6 +22,6 @@ redirect_from: nodejs/reference/
 	</div>
 </header>
 
-		{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","nodejs" | sort: order  %}
+		{% assign languagelist = site.posts | where:"language","nodejs" | sort: order  %}
 
 		{% include posts/documentation_eg.html %}

--- a/_posts/nodejs/2015-04-05-node_js-index.html
+++ b/_posts/nodejs/2015-04-05-node_js-index.html
@@ -4,6 +4,7 @@ permalink: /nodejs/
 description: Plotly's Nodejs graphing library makes interactive, publication-quality graphs online. Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.
 layout: langindex
 language: nodejs
+display_as: false
 redirect_from: nodejs/reference/
 ---
 <header class="--welcome">

--- a/_posts/nodejs/2015-04-05-node_js-index.html
+++ b/_posts/nodejs/2015-04-05-node_js-index.html
@@ -22,6 +22,6 @@ redirect_from: nodejs/reference/
 	</div>
 </header>
 
-		{% assign languagelist = site.posts | where:"language","nodejs" | sort: order  %}
+{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","nodejs" | sort: order  %}
 
 		{% include posts/documentation_eg.html %}

--- a/_posts/plotly_js/2015-04-05-plotly_js-index.html
+++ b/_posts/plotly_js/2015-04-05-plotly_js-index.html
@@ -150,4 +150,4 @@ redirect_from: /javascript-graphing-library/
 </header>
 
 {% assign languagelist = site.posts | where:"language","plotly_js"  | sort: "order" %}
-{% include posts/documentation_eg.html %}
+{% include posts/mainlang_documentation_eg.html %}

--- a/_posts/plotly_js/2015-04-05-plotly_js-index.html
+++ b/_posts/plotly_js/2015-04-05-plotly_js-index.html
@@ -148,5 +148,5 @@ redirect_from: /javascript-graphing-library/
     </div>
 </header>
 
-{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","plotly_js"  | sort: "order" %}
+{% assign languagelist = site.posts | where:"language","plotly_js"  | sort: "order" %}
 {% include posts/documentation_eg.html %}

--- a/_posts/plotly_js/2015-04-05-plotly_js-index.html
+++ b/_posts/plotly_js/2015-04-05-plotly_js-index.html
@@ -4,6 +4,7 @@ permalink: /javascript/
 description: A free open source interactive javascript graphing library. Plotly.js is built on d3.js and webgl and supports over 20 types of interactive charts.
 language: plotly_js
 layout: langindex
+display_as: false
 redirect_from: /javascript-graphing-library/
 ---
 <script src="//cdn.plot.ly/plotly-latest.min.js"></script>

--- a/_posts/plotly_js/fundamentals/eula/2015-07-11-eula.html
+++ b/_posts/plotly_js/fundamentals/eula/2015-07-11-eula.html
@@ -4,7 +4,6 @@ permalink: javascript/eula/
 description: End User License Agreement for Plotly.js and other Plotly products
 layout: langindex
 language: plotly_js
-display_as: chart_type
 sitemap: false
 redirect_from: javascript-graphing-library/eula/
 ---

--- a/_posts/plotly_js/legacy/polar/2015-04-09-polar_plotly_js_index.html
+++ b/_posts/plotly_js/legacy/polar/2015-04-09-polar_plotly_js_index.html
@@ -5,7 +5,6 @@ description: How to graph D3.js-based polar charts in javascript. Seven examples
 layout: base
 thumbnail: thumbnail/polar-scatter.jpg
 language: plotly_js
-display_as: legacy_charts
 order: 1
 redirect_from: javascript-graphing-library/polar-chart/
 ---

--- a/_posts/python/2019-07-03-index.html
+++ b/_posts/python/2019-07-03-index.html
@@ -34,5 +34,5 @@ language: python
 
 
 
-		{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","python"  | sort: "order" %}
+		{% assign languagelist = site.posts | where:"language","python"  | sort: "order" %}
         {% include posts/documentation_eg.html %}

--- a/_posts/python/2019-07-03-index.html
+++ b/_posts/python/2019-07-03-index.html
@@ -1,6 +1,7 @@
 ---
 name: Plotly Python Graphing Library
 permalink: /python/
+display_as: false
 redirect_from:
   - python/next/
   - python/matplotlib-to-plotly-tutorial/

--- a/_posts/python/2019-07-03-index.html
+++ b/_posts/python/2019-07-03-index.html
@@ -35,4 +35,4 @@ language: python
 
 
 		{% assign languagelist = site.posts | where:"language","python"  | sort: "order" %}
-        {% include posts/documentation_eg.html %}
+        {% include posts/mainlang_documentation_eg.html %}

--- a/_posts/r/2015-07-30-r-index.md
+++ b/_posts/r/2015-07-30-r-index.md
@@ -27,4 +27,4 @@ language: r
 
 {% assign languagelist = site.posts | where:"language","r"  | sort: "order"  %}
 
-{% include posts/documentation_eg.html %}
+{% include posts/mainlang_documentation_eg.html %}

--- a/_posts/r/2015-07-30-r-index.md
+++ b/_posts/r/2015-07-30-r-index.md
@@ -25,6 +25,6 @@ language: r
 </header>
 
 
-{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","r"  | sort: "order"  %}
+{% assign languagelist = site.posts | where:"language","r"  | sort: "order"  %}
 
 {% include posts/documentation_eg.html %}

--- a/_posts/r/2015-07-30-r-index.md
+++ b/_posts/r/2015-07-30-r-index.md
@@ -1,6 +1,7 @@
 ---
 name: Plotly R Graphing Library
 permalink: /r/
+display_as: false
 description: Plotly's R graphing library makes interactive, publication-quality graphs. Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, and 3D (WebGL based) charts.
 layout: langindex
 language: r

--- a/_posts/scala/2016-04-13-scala-index.html
+++ b/_posts/scala/2016-04-13-scala-index.html
@@ -24,6 +24,6 @@ language: scala
 </header>
 
 
-{% assign languagelist = site.posts | where:"language","scala"  | sort: "order" %}
+{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","scala"  | sort: "order" %}
 
 {% include posts/documentation_eg.html %}

--- a/_posts/scala/2016-04-13-scala-index.html
+++ b/_posts/scala/2016-04-13-scala-index.html
@@ -3,6 +3,7 @@ name: Plotly Scala Graphing Library
 permalink: /scala/
 description: Plotly's Scala graphing library makes interactive, publication-quality graphs online. Examples of how to make line plots, scatter plots, subplots, and multiple-axes charts.
 layout: langindex
+display_as: false
 language: scala
 ---
 

--- a/_posts/scala/2016-04-13-scala-index.html
+++ b/_posts/scala/2016-04-13-scala-index.html
@@ -24,6 +24,6 @@ language: scala
 </header>
 
 
-{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","scala"  | sort: "order" %}
+{% assign languagelist = site.posts | where:"language","scala"  | sort: "order" %}
 
 {% include posts/documentation_eg.html %}


### PR DESCRIPTION
The purpose of this PR is to refactor `documentation_eg.html` in order to only display the first 5 examples on the language index page while displaying all examples on subindex pages. 

As a result of this refactor, the `display_as:example_index` front-matter is no longer used to determine whether a post is displayed on the language index page. 