### PR TITLE
add canonical link tag

### DIFF
--- a/_includes/layouts/head.html
+++ b/_includes/layouts/head.html
@@ -3,6 +3,8 @@
 
       <meta charset="utf-8"/>
 
+      <link rel="canonical" href="https://plotly.com{{page.url}}"/>
+
       <!-- Media query magic - http://stackoverflow.com/questions/19945658/my-iphone-thinks-its-980px-wide -->
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <script src="/all_static/javascripts/algolia/instantsearch.js"></script>


### PR DESCRIPTION
closes https://github.com/plotly/graphing-library-docs/issues/70 

The purpose of this PR is to make sure each page has a `<link rel="canonical"/>` tag for SEO purposes. 