### PR TITLE
Order fixups rebased

### DIFF
--- a/_posts/ggplot2/2016-12-16-ggplot2-index.md
+++ b/_posts/ggplot2/2016-12-16-ggplot2-index.md
@@ -20,6 +20,6 @@ redirect_from: ggplot2/reference/
   </div>
 </header>
 
-{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","ggplot2"  | sort: "order"  %}
+{% assign languagelist = site.posts | where:"language","ggplot2"  | sort: "order"  %}
 
 {% include posts/documentation_eg.html %}

--- a/_posts/plotly_js/chart-events/2019-09-12-plotly_js-chart-events-index.html
+++ b/_posts/plotly_js/chart-events/2019-09-12-plotly_js-chart-events-index.html
@@ -7,7 +7,7 @@ language: plotly_js
 display_as: chart_events
 thumbnail: thumbnail/mixed.jpg
 page_type: example_index
-order: 25
+order: 5
 ---
 
 

--- a/_posts/plotly_js/controls/callbacks-buttons/2015-04-09-buttons_index.html
+++ b/_posts/plotly_js/controls/callbacks-buttons/2015-04-09-buttons_index.html
@@ -7,7 +7,7 @@ thumbnail: thumbnail/custom-buttons.jpg
 language: plotly_js
 page_type: example_index
 display_as: controls
-order: 3
+order: 2
 redirect_from: javascript-graphing-library/custom-buttons/
 ---
 {% assign examples = site.posts | where:"language","plotly_js" | where:"suite","button-events" | sort: "order" %}

--- a/_posts/plotly_js/controls/callbacks-slider-components/2016-11-03-sliders_index.html
+++ b/_posts/plotly_js/controls/callbacks-slider-components/2016-11-03-sliders_index.html
@@ -7,7 +7,7 @@ thumbnail: thumbnail/slider-component.jpg
 language: plotly_js
 page_type: example_index
 display_as: controls
-order: 5
+order: 3
 ---
 {% assign examples = site.posts | where:"language","plotly_js" | where:"suite","slider-components-events" | sort: "order" %}
 {% include posts/auto_examples.html examples=examples %}

--- a/_posts/plotly_js/controls/lasso/2016-01-27-lasso_plotly_js_index.html
+++ b/_posts/plotly_js/controls/lasso/2016-01-27-lasso_plotly_js_index.html
@@ -7,7 +7,7 @@ thumbnail: thumbnail/lasso.jpg
 language: plotly_js
 page_type: example_index
 display_as: controls
-order: 6
+order: 4
 arrangement: horizontal
 redirect_from: javascript-graphing-library/lasso-selection/
 ---

--- a/_posts/plotly_js/controls/range-slider/2016-04-04-range-slider_plotly_js_index.html
+++ b/_posts/plotly_js/controls/range-slider/2016-04-04-range-slider_plotly_js_index.html
@@ -7,7 +7,7 @@ thumbnail: thumbnail/sliders.jpg
 language: plotly_js
 page_type: example_index
 display_as: controls
-order: 11
+order: 5
 redirect_from: javascript-graphing-library/range-slider/
 ---
 {% assign examples = site.posts | where:"language","plotly_js" | where:"suite","range-slider" | sort: "order" %}

--- a/_posts/python/2019-07-03-chart-studio-index.html
+++ b/_posts/python/2019-07-03-chart-studio-index.html
@@ -8,7 +8,7 @@ language: python
 display_as: chart_studio
 thumbnail: thumbnail/mixed.jpg
 page_type: example_index
-order: 20
+order: 5
 ---
 
 

--- a/_posts/python/chart-studio/2019-07-03-data-api.html
+++ b/_posts/python/chart-studio/2019-07-03-data-api.html
@@ -4,8 +4,8 @@ display_as: chart_studio
 language: python
 layout: base
 name: Plots from Grids
-order: 5
-page_type: u-guide
+order: 4
+page_type: example_index
 permalink: python/data-api/
 thumbnail: thumbnail/table.jpg
 v4upgrade: True

--- a/_posts/python/chart-studio/2019-07-03-delete-plots.html
+++ b/_posts/python/chart-studio/2019-07-03-delete-plots.html
@@ -5,7 +5,7 @@ ipynb: ~notebook_demo/98
 language: python
 layout: base
 name: Deleting Plots
-order: 9
+order: 8
 page_type: u-guide
 permalink: python/delete-plots/
 thumbnail: thumbnail/delete.jpg

--- a/_posts/python/chart-studio/2019-07-03-get-requests.html
+++ b/_posts/python/chart-studio/2019-07-03-get-requests.html
@@ -4,7 +4,7 @@ display_as: chart_studio
 language: python
 layout: base
 name: Working With Chart Studio Graphs
-order: 8
+order: 7
 permalink: python/working-with-chart-studio-graphs/
 redirect_from: python/get-requests
 thumbnail: thumbnail/spectral.jpg

--- a/_posts/python/chart-studio/2019-07-03-getting-started-with-chart-studio.html
+++ b/_posts/python/chart-studio/2019-07-03-getting-started-with-chart-studio.html
@@ -5,7 +5,7 @@ ipynb: ~notebook_demo/123/installation
 language: python
 layout: base
 name: Getting Started with Chart Studio
-order: 0.1
+order: 1
 page_type: example_index
 permalink: python/getting-started-with-chart-studio/
 thumbnail: thumbnail/bubble.jpg

--- a/_posts/python/chart-studio/2019-07-03-ipython-notebook-tutorial.html
+++ b/_posts/python/chart-studio/2019-07-03-ipython-notebook-tutorial.html
@@ -6,7 +6,6 @@ language: python
 layout: base
 name: Jupyter Notebook Tutorial
 order: 10
-page_type: example_index
 permalink: python/ipython-notebook-tutorial/
 redirect_from: ipython-notebooks/ipython-notebook-tutorial/
 thumbnail: thumbnail/ipythonnb.jpg

--- a/_posts/python/chart-studio/2019-07-03-ipython-notebook-tutorial.html
+++ b/_posts/python/chart-studio/2019-07-03-ipython-notebook-tutorial.html
@@ -5,7 +5,7 @@ ipynb: ~chelsea_lyn/14070
 language: python
 layout: base
 name: Jupyter Notebook Tutorial
-order: 11
+order: 10
 page_type: example_index
 permalink: python/ipython-notebook-tutorial/
 redirect_from: ipython-notebooks/ipython-notebook-tutorial/

--- a/_posts/python/chart-studio/2019-07-03-presentations-tool.html
+++ b/_posts/python/chart-studio/2019-07-03-presentations-tool.html
@@ -4,8 +4,8 @@ display_as: chart_studio
 language: python
 layout: base
 name: Presentations Tool
-order: 0.6
-page_type: u-guide
+order: 2
+page_type: example_index
 permalink: python/presentations-tool/
 thumbnail: thumbnail/pres_api.jpg
 v4upgrade: True

--- a/_posts/python/chart-studio/2019-07-03-privacy.html
+++ b/_posts/python/chart-studio/2019-07-03-privacy.html
@@ -5,7 +5,8 @@ ipynb: ~notebook_demo/97
 language: python
 layout: base
 name: Privacy
-order: 2
+order: 3
+page_type: example_index
 permalink: python/privacy/
 thumbnail: thumbnail/privacy.jpg
 v4upgrade: True

--- a/_posts/python/chart-studio/2019-07-03-proxy-configuration.html
+++ b/_posts/python/chart-studio/2019-07-03-proxy-configuration.html
@@ -4,7 +4,7 @@ display_as: chart_studio
 language: python
 layout: base
 name: Requests Behind Corporate Proxies
-order: 10
+order: 9
 permalink: python/proxy-configuration/
 thumbnail: thumbnail/net.jpg
 v4upgrade: True

--- a/_posts/python/chart-studio/ipython-notebook-tutorial.md
+++ b/_posts/python/chart-studio/ipython-notebook-tutorial.md
@@ -31,7 +31,6 @@ jupyter:
     name: Jupyter Notebook Tutorial
     language: python
     display_as: chart_studio
-    page_type: example_index
     order: 11
     ipynb: ~chelsea_lyn/14070
     v4upgrade: true

--- a/_posts/r/chart-studio/2015-07-30-filenames.Rmd
+++ b/_posts/r/chart-studio/2015-07-30-filenames.Rmd
@@ -8,7 +8,6 @@ order: 9
 output:
   html_document:
     keep_md: true
-page_type: example_index
 permalink: r/file-options/
 thumbnail: thumbnail/horizontal-bar.jpg
 ---

--- a/_posts/r/chart-studio/2015-07-30-filenames.md
+++ b/_posts/r/chart-studio/2015-07-30-filenames.md
@@ -8,7 +8,6 @@ order: 9
 output:
   html_document:
     keep_md: true
-page_type: example_index
 permalink: r/file-options/
 thumbnail: thumbnail/horizontal-bar.jpg
 ---

--- a/_posts/r/chart-studio/2016-02-20-jupyter-notebook-r.html
+++ b/_posts/r/chart-studio/2016-02-20-jupyter-notebook-r.html
@@ -5,7 +5,7 @@ language: r
 layout: base
 name: Embed Graphs In Jupyter Notebooks
 order: 4
-page_type: u-guide
+page_type: example_index
 permalink: r/using-r-in-jupyter-notebooks/
 sitemap: false
 thumbnail: thumbnail/png-export.png

--- a/_posts/r/chart-studio/2020-01-17-getting-started-with-chart-studio.Rmd
+++ b/_posts/r/chart-studio/2020-01-17-getting-started-with-chart-studio.Rmd
@@ -2,7 +2,7 @@
 name: Getting Started with Chart Studio
 permalink: r/getting-started-with-chart-studio/
 description: Get started with Chart Studio and Plotly's R graphing library.
-page_type: u-guide
+page_type: example_index
 display_as: chart_studio
 layout: base
 language: r

--- a/_posts/r/chart-studio/2020-01-17-getting-started-with-chart-studio.md
+++ b/_posts/r/chart-studio/2020-01-17-getting-started-with-chart-studio.md
@@ -2,7 +2,7 @@
 name: Getting Started with Chart Studio
 permalink: r/getting-started-with-chart-studio/
 description: Get started with Chart Studio and Plotly's R graphing library.
-page_type: u-guide
+page_type: example_index
 display_as: chart_studio
 layout: base
 language: r


### PR DESCRIPTION
supersedes https://github.com/plotly/graphing-library-docs/pull/74

The purpose of this PR is to refactor `documentation_eg.html` in order to only display the first 5 examples on the language index page while displaying all examples on subindex pages. 

As a result of this refactor, the `display_as:example_index` front-matter is no longer used to determine whether a post is displayed on the language index page. 