### PR TITLE
refactor language index and subindex grid layout

### DIFF
--- a/_includes/layouts/grid-item.html
+++ b/_includes/layouts/grid-item.html
@@ -1,0 +1,10 @@
+<li style="background-image: url({{site.imgurl}}{{page.thumbnail}});" class="--grid-item">
+    <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
+        <div class="--item-meta"><span>{{page.name}}</span></div>
+        <div class="--item-image">
+            <span>View Tutorial</span>
+            <img src="{{site.imgurl}}{{page.thumbnail}}" alt="{{page.name}}">
+        </div>
+    </a>
+
+</li>

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -54,8 +54,6 @@
 {% assign layout_options = true %}
 {% elsif page.display_as == "style_opt" %}
 {% assign style_options = true %}
-{% elsif page.display_as == "legacy_charts" %}
-{% assign legacy_charts = true %}
 {% elsif page.display_as == "databases" %}
 {% assign databases = true %}
 {% elsif page.display_as == "tutorial" %}
@@ -465,29 +463,6 @@
             {% assign counter=0 %}
             {%- for page in languagelist -%}
             {% if page.display_as == "layout_opt" and page.order < 6 or languageindexpage %}
-
-            <li class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                </a>
-            </li>
-            {% assign counter=counter | plus:1 %}
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-{% if legacy_charts %}
-<section class="--tutorial-section no-image" id="legacy-charts">
-    <header class="--section-header"><a href="#legacy-charts">Legacy Charts</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {% assign counter=0 %}
-            {%- for page in languagelist -%}
-            {% if page.display_as == "legacy_charts" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -1,3 +1,15 @@
+{% assign languageindexpage = false %}
+
+{% if page.display_as %}
+{% assign languageindexpage = true %}
+{% endif %}
+
+{% assign mainlanguage = false %}
+
+{% if page.language == "plotly_js" or page.language == "python" or page.language == "r" %}
+{% assign mainlanguage = true %}
+{% endif %}
+
 {% comment %}First, check which sections this page should contain checking all of the posts{% endcomment %}
 {%- for page in languagelist -%}
 {% if page.display_as == "file_settings" %}
@@ -33,18 +45,6 @@
 {% elsif page.display_as == "advanced_opt" %}
 {% assign advanced_opt = true %}
 
-<!-- START OF GGPLOT CUSTOM LAYOUT -->
-{% elsif page.display_as == "aesthetics" %}
-{% assign aesthetics = true %}
-{% elsif page.display_as == "geoms" %}
-{% assign geoms = true %}
-{% elsif page.display_as == "faceting" %}
-{% assign faceting = true %}
-{% elsif page.display_as == "other" %}
-{% assign other = true %}
-{% elsif page.display_as == "theme" %}
-{% assign theme = true %}
-<!-- END OF GGPLOT CUSTOM LAYOUT -->
 {% endif %}
 {%- endfor -%}
 
@@ -88,10 +88,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "file_settings" %}
+            {% if page.display_as == "file_settings" and page.order < 6 or languageindexpage %}
+
 
             {% include layouts/grid-item.html %}
-            
+
 
             {% endif %}
             {%- endfor -%}
@@ -107,10 +108,10 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_type" or page.display_as == "basic" %}
+            {% if page.display_as == "chart_type" or page.display_as == "basic" and page.order < 6 or languageindexpage %}
 
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -127,9 +128,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "statistical" %}
+            {% if page.display_as == "statistical" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -146,9 +147,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "scientific" %}
+            {% if page.display_as == "scientific" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -165,9 +166,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "financial" %}
+            {% if page.display_as == "financial" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -184,9 +185,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "maps" %}
+            {% if page.display_as == "maps" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -203,9 +204,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "3d_charts" %}
+            {% if page.display_as == "3d_charts" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -222,9 +223,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "multiple_axes" %}
+            {% if page.display_as == "multiple_axes" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -241,9 +242,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -260,9 +261,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -279,9 +280,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -298,7 +299,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "transforms" %}
+            {% if page.display_as == "transforms" and page.order < 6 or languageindexpage %}
 
 
                         {% include layouts/grid-item.html %}
@@ -318,9 +319,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "controls" %}
+            {% if page.display_as == "controls" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -337,9 +338,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "animations" %}
+            {% if page.display_as == "animations" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -356,7 +357,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_studio" %}
+            {% if page.display_as == "chart_studio" and page.order < 6 or languageindexpage %}
 
 
                         {% include layouts/grid-item.html %}
@@ -376,9 +377,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "financial_analysis" %}
+            {% if page.display_as == "financial_analysis" and page.order < 6 or languageindexpage %}
 
-                        {% include layouts/grid-item.html %}
+            {% include layouts/grid-item.html %}
 
 
             {% endif %}
@@ -398,7 +399,7 @@
 
 {% assign counter=0 %}
 {%- for page in languagelist -%}
-{% if page.display_as == "layout_opt" %}
+{% if page.display_as == "layout_opt" and page.order < 6 or languageindexpage %}
 {% if counter == 6 %}</ul></div><div class="six columns"><ul>{% endif %}
 <li><a class="no-list-style" href="/{{page.permalink}}">{{page.name}}</a></li>
 {% assign counter=counter | plus:1 %}
@@ -417,7 +418,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "advanced_opt" %}
+            {% if page.display_as == "advanced_opt" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -440,7 +441,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "style_opt" %}
+            {% if page.display_as == "style_opt" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -463,7 +464,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "layout_opt" %}
+            {% if page.display_as == "layout_opt" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -486,7 +487,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "legacy_charts" %}
+            {% if page.display_as == "legacy_charts" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -509,7 +510,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "databases" %}
+            {% if page.display_as == "databases" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -533,7 +534,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "report_generation" %}
+            {% if page.display_as == "report_generation" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -561,7 +562,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" %}
+            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -585,7 +586,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "tutorial" %}
+            {% if page.display_as == "tutorial" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -608,7 +609,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "get_request" %}
+            {% if page.display_as == "get_request" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -631,7 +632,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "mathematics" %}
+            {% if page.display_as == "mathematics" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -655,7 +656,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "statistics" %}
+            {% if page.display_as == "statistics" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -678,7 +679,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "peak-analysis" %}
+            {% if page.display_as == "peak-analysis" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -701,7 +702,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "signal-analysis" %}
+            {% if page.display_as == "signal-analysis" and page.order < 6 or languageindexpage %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -726,7 +727,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "aesthetics" %}
+            {% if page.display_as == "aesthetics" and page.order < 6 or languageindexpage %}
                         {% include layouts/grid-item.html %}
 
 
@@ -746,7 +747,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "geoms" %}
+            {% if page.display_as == "geoms" and page.order < 6 or languageindexpage %}
                         {% include layouts/grid-item.html %}
 
 
@@ -765,7 +766,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "faceting" %}
+            {% if page.display_as == "faceting" and page.order < 6 or languageindexpage %}
                         {% include layouts/grid-item.html %}
 
 
@@ -784,7 +785,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "other" %}
+            {% if page.display_as == "other" and page.order < 6 or languageindexpage %}
                         {% include layouts/grid-item.html %}
 
 
@@ -805,7 +806,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "theme" %}
+            {% if page.display_as == "theme" and page.order < 6 or languageindexpage %}
 
 
                         {% include layouts/grid-item.html %}

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -1,15 +1,3 @@
-{% assign subindexpage = false %}
-
-{% if page.display_as %}
-{% assign subindexpage = true %}
-{% endif %}
-
-{% assign subindexpage = false %}
-
-{% if page.language == "plotly_js" or page.language == "python" or page.language == "r" %}
-{% assign subindexpage = true %}
-{% endif %}
-
 {% comment %}First, check which sections this page should contain checking all of the posts{% endcomment %}
 {%- for page in languagelist -%}
 {% if page.display_as == "file_settings" %}

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -12,8 +12,6 @@
 
 {% assign order_elligible = order_elligible %}
 
-{% assign category_elligible = page.display_as == "chart_type" or page.display_as == "basic" %}
-
 {% comment %}First, check which sections this page should contain checking all of the posts{% endcomment %}
 {%- for page in languagelist -%}
 {% if page.display_as == "file_settings" %}
@@ -42,8 +40,6 @@
 {% assign animations = true %}
 {% elsif page.display_as == "chart_events" %}
 {% assign chart_events = true %}
-{% elsif page.display_as == "financial_analysis" %}
-{% assign financial_analysis = true %}
 {% elsif page.display_as == "chart_studio" %}
 {% assign chart_studio = true %}
 {% elsif page.display_as == "advanced_opt" %}
@@ -58,24 +54,6 @@
 {% assign layout_options = true %}
 {% elsif page.display_as == "style_opt" %}
 {% assign style_options = true %}
-{% elsif page.display_as == "databases" %}
-{% assign databases = true %}
-{% elsif page.display_as == "tutorial" %}
-{% assign tutorial = true %}
-{% elsif page.display_as == "get_request" %}
-{% assign get_request = true %}
-{% elsif page.display_as == "report_generation" %}
-{% assign report_generation = true %}
-{% elsif page.display_as == "mathematics" %}
-{% assign mathematics = true %}
-{% elsif page.display_as == "statistics" %}
-{% assign statistics = true %}
-{% elsif page.display_as == "peak-analysis" %}
-{% assign peak-analysis = true %}
-{% elsif page.display_as == "signal-analysis" %}
-{% assign signal-analysis = true %}
-{% elsif page.display_as == "text_documents" %}
-{% assign text_documents = true %}
 {% endif %}
 {%- endfor -%}
 
@@ -110,7 +88,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if category_elligible and order_elligible %}
+            {% if chart_type and order_elligible %}
 
 
             {% include layouts/grid-item.html %}
@@ -391,27 +369,6 @@
 </section>
 {% endif %}
 
-{% if layout_options_ggplot %}
-<hr>
-<h4 class="example-section-title" id="layout-options">
-<a class="no_underline plot-blue" href="#layout-options">Layout Options</a></h4>
-<div class="row">
-<div class="six columns">
-<ul >
-
-{% assign counter=0 %}
-{%- for page in languagelist -%}
-{% if page.display_as == "layout_opt" and order_elligible %}
-{% if counter == 6 %}</ul></div><div class="six columns"><ul>{% endif %}
-<li><a class="no-list-style" href="/{{page.permalink}}">{{page.name}}</a></li>
-{% assign counter=counter | plus:1 %}
-{% endif %}
-{%- endfor -%}
-</ul>
-</div>
-</div>
-{% endif %}
-
 {% if advanced_opt %}
 <section class="--tutorial-section no-image" id="advanced-options">
     <header class="--section-header"><a href="#advanced-options">Advanced</a>
@@ -481,54 +438,6 @@
 </section>
 {% endif %}
 
-{% if databases %}
-<section class="--tutorial-section no-image" id="databases">
-    <header class="--section-header"><a href="#databases">Connecting to Databases</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {% assign counter=0 %}
-            {%- for page in languagelist -%}
-            {% if page.display_as == "databases" and order_elligible %}
-
-            <li class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-
-                </a>
-            </li>
-            {% assign counter=counter | plus:1 %}
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-{% if report_generation %}
-<section class="--tutorial-section no-image" id="report-generation">
-    <header class="--section-header"><a href="#report-generation">Report Generation</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {% assign counter=0 %}
-            {%- for page in languagelist -%}
-            {% if page.display_as == "report_generation" and order_elligible %}
-
-            <li class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-
-                </a>
-            </li>
-            {% assign counter=counter | plus:1 %}
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
 {% if chart_events and page.language !="plotly_js" and page.language !="python" and page.language != "r" %}
 <section class="--tutorial-section no-image" id="chart-events">
     <header class="--section-header"><a href="#chart-events">Add Custom Controls with JavaScript</a>
@@ -555,250 +464,4 @@
         </ul>
     </section>
 </section>
-{% endif %}
-
-{% if tutorial %}
-<section class="--tutorial-section no-image" id="tutorial">
-    <header class="--section-header"><a href="#tutorial">Tutorial</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {% assign counter=0 %}
-            {%- for page in languagelist -%}
-            {% if page.display_as == "tutorial" and order_elligible %}
-
-            <li class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-				</a>
-            </li>
-            {% assign counter=counter | plus:1 %}
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-{% if get_request %}
-<section class="--tutorial-section no-image" id="static-image-export">
-    <header class="--section-header"><a href="#static-image-export">Image Export &amp; Retrieving Plots</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {% assign counter=0 %}
-            {%- for page in languagelist -%}
-            {% if page.display_as == "get_request" and order_elligible %}
-
-            <li class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                </a>
-            </li>
-            {% assign counter=counter | plus:1 %}
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-{% if mathematics %}
-<section class="--tutorial-section no-image" id="mathematics">
-    <header class="--section-header"><a href="#mathematics">Mathematics</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {% assign counter=0 %}
-            {%- for page in languagelist -%}
-            {% if page.display_as == "mathematics" and order_elligible %}
-
-            <li class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                </a>
-            </li>
-            {% assign counter=counter | plus:1 %}
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-{% if statistics %}
-<section class="--tutorial-section no-image" id="statistics">
-    <header class="--section-header"><a href="#statistics">Statistics</a>
-
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {% assign counter=0 %}
-            {%- for page in languagelist -%}
-            {% if page.display_as == "statistics" and order_elligible %}
-
-            <li class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                </a>
-            </li>
-            {% assign counter=counter | plus:1 %}
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-{% if peak-analysis %}
-<section class="--tutorial-section no-image" id="peak-analysis">
-    <header class="--section-header"><a href="#peak-analysis">Peak Analysis</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {% assign counter=0 %}
-            {%- for page in languagelist -%}
-            {% if page.display_as == "peak-analysis" and order_elligible %}
-
-            <li class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                </a>
-            </li>
-            {% assign counter=counter | plus:1 %}
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-{% if signal-analysis %}
-<section class="--tutorial-section no-image" id="signal-analysis">
-    <header class="--section-header"><a href="#signal-analysis">Signal Analysis</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {% assign counter=0 %}
-            {%- for page in languagelist -%}
-            {% if page.display_as == "signal-analysis" and order_elligible %}
-
-            <li class="--grid-item">
-                <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
-                    <div class="--item-meta"><span>{{page.name}}</span></div>
-                </a>
-            </li>
-            {% assign counter=counter | plus:1 %}
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-<!-- START OF GGPLOT CUSTOM LAYOUT -->
-
-<!-- Aesthetics -->
-{% if aesthetics %}
-<section class="--tutorial-section">
-    <header class="--section-header"><a href="#aes" id="aes">Aesthetics</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {%- for page in languagelist -%}
-            {% if page.display_as == "aesthetics" and order_elligible %}
-                        {% include layouts/grid-item.html %}
-
-
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-
-{% endif %}
-
-<!-- Geoms -->
-{% if geoms %}
-<section class="--tutorial-section">
-    <header class="--section-header"><a href="#geoms" id="geoms">Geoms</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {%- for page in languagelist -%}
-            {% if page.display_as == "geoms" and order_elligible %}
-                        {% include layouts/grid-item.html %}
-
-
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-<!-- Faceting -->
-{% if faceting %}
-<section class="--tutorial-section">
-    <header class="--section-header"><a href="#faceting" id="faceting">Faceting</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {%- for page in languagelist -%}
-            {% if page.display_as == "faceting" and order_elligible %}
-                        {% include layouts/grid-item.html %}
-
-
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-<!-- Other -->
-{% if other %}
-<section class="--tutorial-section">
-    <header class="--section-header"><a href="#other" id="other">Other</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {%- for page in languagelist -%}
-            {% if page.display_as == "other" and order_elligible %}
-                        {% include layouts/grid-item.html %}
-
-
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-
-<!-- theme -->
-
-{% if theme %}
-
-<section class="--tutorial-section">
-    <header class="--section-header"><a href="#theme" id="theme">theme</a>
-    </header>
-    <section class="--grid">
-        <ul class="--grid-list">
-            {%- for page in languagelist -%}
-            {% if page.display_as == "theme" and order_elligible %}
-
-
-                        {% include layouts/grid-item.html %}
-
-
-            {% endif %}
-            {%- endfor -%}
-        </ul>
-    </section>
-</section>
-{% endif %}
-<!-- END OF GGPLOT CUSTOM LAYOUT -->
-
-{% if page.language == "matlab" %}
-<p><em>MATLAB is a registered trademark of The MathWorks, Inc.</em></p>
 {% endif %}

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -54,17 +54,10 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "file_settings" and order_elligible %} 
+            {% if page.display_as == "file_settings" and page.order < 6 %} 
 
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -79,11 +72,6 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
 
             {% assign category_elligible = false %}
 
@@ -91,12 +79,10 @@
             {% assign category_elligible = true %}
             {% endif %}
 
-            {% if category_elligible and order_elligible %}
+            {% if category_elligible and page.order < 6 %}
 
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -111,16 +97,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "statistical" and order_elligible %}
+            {% if page.display_as == "statistical" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -135,16 +114,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "scientific" and order_elligible %}
+            {% if page.display_as == "scientific" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -159,16 +131,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "financial" and order_elligible %}
+            {% if page.display_as == "financial" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -183,16 +148,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "maps" and order_elligible %}
+            {% if page.display_as == "maps" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -207,16 +165,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "3d_charts" and order_elligible %}
+            {% if page.display_as == "3d_charts" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -231,16 +182,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "multiple_axes" and order_elligible %}
+            {% if page.display_as == "multiple_axes" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -255,16 +199,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "chart_events" and order_elligible %}
+            {% if page.display_as == "chart_events" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -279,16 +216,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "chart_events" and order_elligible %}
+            {% if page.display_as == "chart_events" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -303,16 +233,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "chart_events" and order_elligible %}
+            {% if page.display_as == "chart_events" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -327,17 +250,10 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "transforms" and order_elligible %}
+            {% if page.display_as == "transforms" and page.order < 6 %}
 
 
                         {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -352,16 +268,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "controls" and order_elligible %}
+            {% if page.display_as == "controls" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -376,16 +285,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "animations" and order_elligible %}
+            {% if page.display_as == "animations" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -400,17 +302,10 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "chart_studio" and order_elligible %}
+            {% if page.display_as == "chart_studio" and page.order < 6 %}
 
 
                         {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -425,16 +320,9 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "financial_analysis" and order_elligible %}
+            {% if page.display_as == "financial_analysis" and page.order < 6 %}
 
             {% include layouts/grid-item.html %}
-
-
             {% endif %}
             {%- endfor -%}
         </ul>
@@ -450,12 +338,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "advanced_opt" and order_elligible %}
+            {% if page.display_as == "advanced_opt" and page.order < 6 %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -478,12 +361,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "style_opt" and order_elligible %}
+            {% if page.display_as == "style_opt" and page.order < 6 %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -506,12 +384,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "layout_opt" and order_elligible %}
+            {% if page.display_as == "layout_opt" and page.order < 6 %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -538,12 +411,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% assign order_elligible = false %}
-
-            {% if page.order < 6  %}
-            {% assign order_elligible = true %}
-            {% endif %}
-            {% if page.display_as == "chart_events" and order_elligible %}
+            {% if page.display_as == "chart_events" and page.order < 6 %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -4,13 +4,11 @@
 {% assign subindexpage = true %}
 {% endif %}
 
-{% assign mainlanguage = false %}
+{% assign subindexpage = false %}
 
 {% if page.language == "plotly_js" or page.language == "python" or page.language == "r" %}
-{% assign mainlanguage = true %}
+{% assign subindexpage = true %}
 {% endif %}
-
-{% assign order_elligible = order_elligible %}
 
 {% comment %}First, check which sections this page should contain checking all of the posts{% endcomment %}
 {%- for page in languagelist -%}
@@ -68,6 +66,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "file_settings" and order_elligible %} 
 
 
@@ -88,7 +91,19 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if chart_type and order_elligible %}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
+
+            {% assign category_elligible = false %}
+
+            {% if page.display_as == "chart_type" or page.display_as == "basic"  %}
+            {% assign category_elligible = true %}
+            {% endif %}
+
+            {% if category_elligible and order_elligible %}
 
 
             {% include layouts/grid-item.html %}
@@ -108,6 +123,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "statistical" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -127,6 +147,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "scientific" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -146,6 +171,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "financial" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -165,6 +195,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "maps" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -184,6 +219,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "3d_charts" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -203,6 +243,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "multiple_axes" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -222,6 +267,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "chart_events" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -241,6 +291,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "chart_events" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -260,6 +315,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "chart_events" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -279,6 +339,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "transforms" and order_elligible %}
 
 
@@ -299,6 +364,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "controls" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -318,6 +388,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "animations" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -337,6 +412,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "chart_studio" and order_elligible %}
 
 
@@ -357,6 +437,11 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "financial_analysis" and order_elligible %}
 
             {% include layouts/grid-item.html %}
@@ -377,6 +462,11 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "advanced_opt" and order_elligible %}
 
             <li class="--grid-item">
@@ -400,6 +490,11 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "style_opt" and order_elligible %}
 
             <li class="--grid-item">
@@ -423,6 +518,11 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "layout_opt" and order_elligible %}
 
             <li class="--grid-item">
@@ -450,6 +550,11 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
+            {% assign order_elligible = false %}
+
+            {% if page.order < 6  %}
+            {% assign order_elligible = true %}
+            {% endif %}
             {% if page.display_as == "chart_events" and order_elligible %}
 
             <li class="--grid-item">

--- a/_includes/posts/mainlang_documentation_eg.html
+++ b/_includes/posts/mainlang_documentation_eg.html
@@ -1,7 +1,7 @@
-{% assign languageindexpage = false %}
+{% assign subindexpage = false %}
 
 {% if page.display_as %}
-{% assign languageindexpage = true %}
+{% assign subindexpage = true %}
 {% endif %}
 
 {% assign mainlanguage = false %}
@@ -9,6 +9,10 @@
 {% if page.language == "plotly_js" or page.language == "python" or page.language == "r" %}
 {% assign mainlanguage = true %}
 {% endif %}
+
+{% assign order_elligible = order_elligible %}
+
+{% assign category_elligible = page.display_as == "chart_type" or page.display_as == "basic" %}
 
 {% comment %}First, check which sections this page should contain checking all of the posts{% endcomment %}
 {%- for page in languagelist -%}
@@ -86,7 +90,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "file_settings" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "file_settings" and order_elligible %} 
 
 
             {% include layouts/grid-item.html %}
@@ -106,7 +110,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_type" or page.display_as == "basic" and page.order < 6 or languageindexpage %}
+            {% if category_elligible and order_elligible %}
 
 
             {% include layouts/grid-item.html %}
@@ -126,7 +130,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "statistical" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "statistical" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -145,7 +149,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "scientific" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "scientific" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -164,7 +168,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "financial" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "financial" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -183,7 +187,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "maps" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "maps" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -202,7 +206,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "3d_charts" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "3d_charts" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -221,7 +225,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "multiple_axes" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "multiple_axes" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -240,7 +244,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "chart_events" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -259,7 +263,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "chart_events" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -278,7 +282,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "chart_events" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -297,7 +301,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "transforms" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "transforms" and order_elligible %}
 
 
                         {% include layouts/grid-item.html %}
@@ -317,7 +321,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "controls" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "controls" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -336,7 +340,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "animations" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "animations" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -355,7 +359,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_studio" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "chart_studio" and order_elligible %}
 
 
                         {% include layouts/grid-item.html %}
@@ -375,7 +379,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "financial_analysis" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "financial_analysis" and order_elligible %}
 
             {% include layouts/grid-item.html %}
 
@@ -397,7 +401,7 @@
 
 {% assign counter=0 %}
 {%- for page in languagelist -%}
-{% if page.display_as == "layout_opt" and page.order < 6 or languageindexpage %}
+{% if page.display_as == "layout_opt" and order_elligible %}
 {% if counter == 6 %}</ul></div><div class="six columns"><ul>{% endif %}
 <li><a class="no-list-style" href="/{{page.permalink}}">{{page.name}}</a></li>
 {% assign counter=counter | plus:1 %}
@@ -416,7 +420,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "advanced_opt" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "advanced_opt" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -439,7 +443,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "style_opt" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "style_opt" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -462,7 +466,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "layout_opt" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "layout_opt" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -485,7 +489,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "databases" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "databases" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -509,7 +513,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "report_generation" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "report_generation" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -537,7 +541,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "chart_events" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "chart_events" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -561,7 +565,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "tutorial" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "tutorial" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -584,7 +588,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "get_request" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "get_request" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -607,7 +611,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "mathematics" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "mathematics" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -631,7 +635,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "statistics" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "statistics" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -654,7 +658,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "peak-analysis" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "peak-analysis" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -677,7 +681,7 @@
         <ul class="--grid-list">
             {% assign counter=0 %}
             {%- for page in languagelist -%}
-            {% if page.display_as == "signal-analysis" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "signal-analysis" and order_elligible %}
 
             <li class="--grid-item">
                 <a href="{% if page.permalink contains 'http' %}{{page.permalink}}{% else %}/{{page.permalink}}{% endif %}">
@@ -702,7 +706,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "aesthetics" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "aesthetics" and order_elligible %}
                         {% include layouts/grid-item.html %}
 
 
@@ -722,7 +726,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "geoms" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "geoms" and order_elligible %}
                         {% include layouts/grid-item.html %}
 
 
@@ -741,7 +745,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "faceting" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "faceting" and order_elligible %}
                         {% include layouts/grid-item.html %}
 
 
@@ -760,7 +764,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "other" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "other" and order_elligible %}
                         {% include layouts/grid-item.html %}
 
 
@@ -781,7 +785,7 @@
     <section class="--grid">
         <ul class="--grid-list">
             {%- for page in languagelist -%}
-            {% if page.display_as == "theme" and page.order < 6 or languageindexpage %}
+            {% if page.display_as == "theme" and order_elligible %}
 
 
                         {% include layouts/grid-item.html %}

--- a/_posts/ggplot2/2016-12-16-ggplot2-index.md
+++ b/_posts/ggplot2/2016-12-16-ggplot2-index.md
@@ -20,6 +20,6 @@ redirect_from: ggplot2/reference/
   </div>
 </header>
 
-{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","ggplot2"  | sort: "order"  %}
+{% assign languagelist = site.posts | where:"language","ggplot2"  | sort: "order"  %}
 
 {% include posts/documentation_eg.html %}

--- a/_posts/julia/2015-04-05-julia-index.html
+++ b/_posts/julia/2015-04-05-julia-index.html
@@ -4,7 +4,6 @@ permalink: /julia/
 description: Plotly's Julia graphing library makes interactive, publication-quality graphs online. Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.
 layout: langindex
 language: julia
-display_as: false
 redirect_from: julia/reference/
 ---
 

--- a/_posts/julia/2015-04-05-julia-index.html
+++ b/_posts/julia/2015-04-05-julia-index.html
@@ -4,6 +4,7 @@ permalink: /julia/
 description: Plotly's Julia graphing library makes interactive, publication-quality graphs online. Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.
 layout: langindex
 language: julia
+display_as: false
 redirect_from: julia/reference/
 ---
 
@@ -26,6 +27,6 @@ redirect_from: julia/reference/
 </header>
 
 	<h2>Documentation Examples</h2>
-		{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","julia" | sort: "order" %}
+	{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","julia" | sort: "order" %}
 
 		{% include posts/documentation_eg.html %}

--- a/_posts/matlab/2015-04-05-matlab-index.html
+++ b/_posts/matlab/2015-04-05-matlab-index.html
@@ -4,6 +4,7 @@ permalink: /matlab/
 description: Create interactive charts in your web browser with MATLAB<sup>&reg;</sup> and Plotly.
 layout: langindex
 language: matlab
+display_as: false
 ---
 
 
@@ -89,6 +90,6 @@ fig2plotly(gcf, 'offline', true);</code></pre>
 	<br>
 
 	<h2>Documentation Examples</h2>
-		{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","matlab"  | sort: "order" %}
+	{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","matlab"  | sort: "order" %}
 
 		{% include posts/documentation_eg.html %}

--- a/_posts/matlab/2015-04-05-matlab-index.html
+++ b/_posts/matlab/2015-04-05-matlab-index.html
@@ -4,7 +4,6 @@ permalink: /matlab/
 description: Create interactive charts in your web browser with MATLAB<sup>&reg;</sup> and Plotly.
 layout: langindex
 language: matlab
-display_as: false
 ---
 
 

--- a/_posts/nodejs/2015-04-05-node_js-index.html
+++ b/_posts/nodejs/2015-04-05-node_js-index.html
@@ -4,6 +4,7 @@ permalink: /nodejs/
 description: Plotly's Nodejs graphing library makes interactive, publication-quality graphs online. Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.
 layout: langindex
 language: nodejs
+display_as: false
 redirect_from: nodejs/reference/
 ---
 <header class="--welcome">
@@ -21,6 +22,6 @@ redirect_from: nodejs/reference/
 	</div>
 </header>
 
-		{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","nodejs" | sort: order  %}
+{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","nodejs" | sort: order  %}
 
 		{% include posts/documentation_eg.html %}

--- a/_posts/nodejs/2015-04-05-node_js-index.html
+++ b/_posts/nodejs/2015-04-05-node_js-index.html
@@ -4,7 +4,6 @@ permalink: /nodejs/
 description: Plotly's Nodejs graphing library makes interactive, publication-quality graphs online. Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, polar charts and bubble charts.
 layout: langindex
 language: nodejs
-display_as: false
 redirect_from: nodejs/reference/
 ---
 <header class="--welcome">

--- a/_posts/plotly_js/2015-04-05-plotly_js-index.html
+++ b/_posts/plotly_js/2015-04-05-plotly_js-index.html
@@ -4,6 +4,7 @@ permalink: /javascript/
 description: A free open source interactive javascript graphing library. Plotly.js is built on d3.js and webgl and supports over 20 types of interactive charts.
 language: plotly_js
 layout: langindex
+display_as: false
 redirect_from: /javascript-graphing-library/
 ---
 <script src="//cdn.plot.ly/plotly-latest.min.js"></script>
@@ -148,5 +149,5 @@ redirect_from: /javascript-graphing-library/
     </div>
 </header>
 
-{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","plotly_js"  | sort: "order" %}
-{% include posts/documentation_eg.html %}
+{% assign languagelist = site.posts | where:"language","plotly_js"  | sort: "order" %}
+{% include posts/mainlang_documentation_eg.html %}

--- a/_posts/plotly_js/fundamentals/eula/2015-07-11-eula.html
+++ b/_posts/plotly_js/fundamentals/eula/2015-07-11-eula.html
@@ -4,7 +4,6 @@ permalink: javascript/eula/
 description: End User License Agreement for Plotly.js and other Plotly products
 layout: langindex
 language: plotly_js
-display_as: chart_type
 sitemap: false
 redirect_from: javascript-graphing-library/eula/
 ---

--- a/_posts/plotly_js/legacy/polar/2015-04-09-polar_plotly_js_index.html
+++ b/_posts/plotly_js/legacy/polar/2015-04-09-polar_plotly_js_index.html
@@ -5,7 +5,6 @@ description: How to graph D3.js-based polar charts in javascript. Seven examples
 layout: base
 thumbnail: thumbnail/polar-scatter.jpg
 language: plotly_js
-display_as: legacy_charts
 order: 1
 redirect_from: javascript-graphing-library/polar-chart/
 ---

--- a/_posts/python/2019-07-03-chart-events-index.html
+++ b/_posts/python/2019-07-03-chart-events-index.html
@@ -14,7 +14,7 @@ language: python
 display_as: chart_events
 thumbnail: thumbnail/mixed.jpg
 page_type: example_index
-order: 109
+order: 5
 ---
 
 

--- a/_posts/python/2019-07-03-index.html
+++ b/_posts/python/2019-07-03-index.html
@@ -1,6 +1,7 @@
 ---
 name: Plotly Python Graphing Library
 permalink: /python/
+display_as: false
 redirect_from:
   - python/next/
   - python/matplotlib-to-plotly-tutorial/
@@ -33,5 +34,5 @@ language: python
 
 
 
-		{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","python"  | sort: "order" %}
-        {% include posts/documentation_eg.html %}
+		{% assign languagelist = site.posts | where:"language","python"  | sort: "order" %}
+        {% include posts/mainlang_documentation_eg.html %}

--- a/_posts/r/2015-07-30-r-index.md
+++ b/_posts/r/2015-07-30-r-index.md
@@ -1,6 +1,7 @@
 ---
 name: Plotly R Graphing Library
 permalink: /r/
+display_as: false
 description: Plotly's R graphing library makes interactive, publication-quality graphs. Examples of how to make line plots, scatter plots, area charts, bar charts, error bars, box plots, histograms, heatmaps, subplots, multiple-axes, and 3D (WebGL based) charts.
 layout: langindex
 language: r
@@ -24,6 +25,6 @@ language: r
 </header>
 
 
-{% assign languagelist = site.posts | where:"page_type","example_index" | where:"language","r"  | sort: "order"  %}
+{% assign languagelist = site.posts | where:"language","r"  | sort: "order"  %}
 
-{% include posts/documentation_eg.html %}
+{% include posts/mainlang_documentation_eg.html %}

--- a/_posts/scala/2016-04-13-scala-index.html
+++ b/_posts/scala/2016-04-13-scala-index.html
@@ -3,6 +3,7 @@ name: Plotly Scala Graphing Library
 permalink: /scala/
 description: Plotly's Scala graphing library makes interactive, publication-quality graphs online. Examples of how to make line plots, scatter plots, subplots, and multiple-axes charts.
 layout: langindex
+display_as: false
 language: scala
 ---
 

--- a/_posts/scala/2016-04-13-scala-index.html
+++ b/_posts/scala/2016-04-13-scala-index.html
@@ -3,7 +3,6 @@ name: Plotly Scala Graphing Library
 permalink: /scala/
 description: Plotly's Scala graphing library makes interactive, publication-quality graphs online. Examples of how to make line plots, scatter plots, subplots, and multiple-axes charts.
 layout: langindex
-display_as: false
 language: scala
 ---
 


### PR DESCRIPTION
The purpose of this PR is to refactor how examples are displayed on the language index pages for Python, R and JS. A new layout include, `mainlang_documentation.html`, is used just in those three languages to achieve the refactor. 

As a result of this PR, examples will show up on the language index page for Python, R, and JS if they have `order` less than 6. The `page_type: example_index` front-matter is no longer used to determine whether an example should be on the language index page for those 3 languages. 