### PR TITLE
get rid of unneeded logic in order script

### DIFF
--- a/check-or-enforce-order.py
+++ b/check-or-enforce-order.py
@@ -33,7 +33,7 @@ def enforceOrder(list_to_be_ordered):
     for index, post in enumerate(list_to_be_ordered):
         post_to_be_altered = fm.load(str(post))
         if folder_path == "python": # accounts for the fact that this is also run in the plotly.py-docs repo
-            post_to_be_altered.metadata["jupyter"]["plotly"]['order'] = (index+2 if index>=4 else index+1)
+            post_to_be_altered.metadata["jupyter"]["plotly"]['order'] = index+1
             fm.dump(post_to_be_altered, str(post))
         else:        
             post_to_be_altered.metadata['order'] = index+1


### PR DESCRIPTION
The `check-or-enforce-order.py` script no longer has to deal with posts in the plotly.py or plotly.r repo not having `order: 5`. 