### PR TITLE
Fix CSS on /python/renderers

### DIFF
--- a/all_static/css/main.css
+++ b/all_static/css/main.css
@@ -6731,7 +6731,6 @@ div#notebook_panel {
   height: 100%; }
 
 #notebook {
-  font-size: 14px;
   line-height: 20px;
   overflow-y: hidden;
   overflow-x: auto;
@@ -6741,8 +6740,7 @@ div#notebook_panel {
   outline: none;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  min-height: 100%; }
+  -webkit-box-sizing: border-box; }
 
 @media not print {
   #notebook-container {


### PR DESCRIPTION
Before: 
<img width="1552" alt="Screen Shot 2020-08-09 at 10 18 10 PM" src="https://user-images.githubusercontent.com/1557650/89747937-f8a51100-da8e-11ea-97eb-50f31cb90daa.png">


After:
<img width="1552" alt="Screen Shot 2020-08-09 at 10 16 31 PM" src="https://user-images.githubusercontent.com/1557650/89747944-0064b580-da8f-11ea-9245-469d0691d92f.png">

closes https://github.com/plotly/graphing-library-docs/issues/91