### PR TITLE
[plotly.js] Fundamentals -> Text templates: Fix links to point to JS

### DIFF
--- a/_posts/plotly_js/fundamentals/texttemplate/2019-10-21-add_text_template.html
+++ b/_posts/plotly_js/fundamentals/texttemplate/2019-10-21-add_text_template.html
@@ -6,7 +6,7 @@ order: 1
 sitemap: false
 arrangement: horizontal
 markdown_content: |
-   To show an arbitrary text in your chart you can use [texttemplate](https://plotly.com/python/reference/pie/#pie-texttemplate), which is a template string used for rendering the information, and will override [textinfo](https://plotly.com/python/reference/treemap/#treemap-textinfo).
+   To show an arbitrary text in your chart you can use [texttemplate](https://plotly.com/javascript/reference/pie/#pie-texttemplate), which is a template string used for rendering the information, and will override [textinfo](https://plotly.com/javascript/reference/treemap/#treemap-textinfo).
 ---
 var data = [{
   type: "pie",

--- a/_posts/plotly_js/fundamentals/texttemplate/2019-10-21-customize_text_template.html
+++ b/_posts/plotly_js/fundamentals/texttemplate/2019-10-21-customize_text_template.html
@@ -6,7 +6,7 @@ order: 2
 sitemap: false
 arrangement: horizontal
 markdown_content: |
-   The following example uses [textfont](https://plotly.com/python/reference/scatterternary/#scatterternary-textfont) to customize the added text.
+   The following example uses [textfont](https://plotly.com/javascript/reference/scatterternary/#scatterternary-textfont) to customize the added text.
 ---
 var data = [{
       type: "scatterternary",


### PR DESCRIPTION
Fix links for both sections at https://plotly.com/javascript/texttemplate/ to point to JS