### PR TITLE
Adapted code for newer versions of Julia

### DIFF
--- a/_posts/julia/getting-started/2015-05-25-getting-started_julia_index.html
+++ b/_posts/julia/getting-started/2015-05-25-getting-started_julia_index.html
@@ -15,7 +15,7 @@ language: julia
                 Install using Julia's <code class="no-padding">Pkg</code> module. From the Julia REPL:
             </p>
 
-            <pre><code>Pkg.clone("https://github.com/plotly/Plotly.jl")</code></pre>
+            <pre><code>Pkg.add("Plotly")</code></pre>
         </div>
     </section>
 


### PR DESCRIPTION
Pkg.clone seems to be deprecated (see https://discourse.julialang.org/t/is-pkg-clone-replaced-by-pkg-add-in-v1-0-3/19879).