### PR TITLE
Yarn Install has been replaced with add

### DIFF
--- a/_posts/plotly_js/2015-07-21-plotlyjs-getting-started.html
+++ b/_posts/plotly_js/2015-07-21-plotlyjs-getting-started.html
@@ -12,7 +12,7 @@ redirect_from: javascript-graphing-library/getting-started/
         <h2>NPM</h2>
         <div class="content-box">
             <p>
-                You can <a href="https://www.npmjs.com/package/plotly.js" target="_blank">install Plotly.js from NPM</a> via <code>npm install plotly.js-dist</code> or <code>yarn install plotly.js-dist</code>
+                You can <a href="https://www.npmjs.com/package/plotly.js" target="_blank">install Plotly.js from NPM</a> via <code>npm install plotly.js-dist</code> or <code>yarn add plotly.js-dist</code>
             </p>
 
     </section>


### PR DESCRIPTION
Simple one-word fix for Yarn command

If you try to run the command that is currently in docs (`yarn install plotly.js-dist`) you would get an error message like following: error `install` has been replaced with `add` to add new dependencies. Run "yarn add plotly.js-dist" instead.

This PR changes the command to `add`, which is the correct one to install new dependencies.