### PR TITLE
Adding R AI index page

### DIFF
--- a/_posts/r/2021-08-17-ai-index.md
+++ b/_posts/r/2021-08-17-ai-index.md
@@ -1,0 +1,27 @@
+---
+description: Plotly's R graphing library makes interactive, publication-quality graphs online. Examples of how to make charts related to artificial intelligence and machine learning.
+display_as: ai_ml
+language: r
+layout: langindex
+name: AI and ML Charts
+page_type: example_index
+permalink: r/ai-ml/
+thumbnail: thumbnail/mixed.jpg
+---
+
+<header class="--welcome">
+	<div class="--welcome-body">
+		<!--div.--wrap-inner-->
+		<div class="--title">
+
+			<div class="--body">
+				<h1>Plotly R Open Source Graphing Library Artificial Intelligence and Machine Learning Charts</h1>
+				<p>{{page.description}}</p>
+				{% include layouts/dashplug.html %}
+			</div>
+		</div>
+	</div>
+</header>
+
+		{% assign languagelist = site.posts | where:"language","r" | where:"display_as","ai_ml" | where: "layout","base" | sort: "order" %}
+        {% include posts/documentation_eg.html %}


### PR DESCRIPTION
This PR adds the index page for the AI/ML page on the R graphing library docs. 