### PR TITLE
main.css: sets .wrap's max-width from 1440px to 4000px

### DIFF
--- a/all_static/css/main.css
+++ b/all_static/css/main.css
@@ -1529,8 +1529,9 @@ header.header-main {
 
 .\--wrap {
   width: 95%;
-  max-width: 1440px;
-  margin: auto; }
+  max-width: 4000px;
+  margin: auto; 
+}
 
 .plotly-social-media-small li:hover a div.icon {
   opacity: 1; }
@@ -1627,7 +1628,8 @@ header.header-main {
   text-decoration: none; }
 
 .\--page.\--index .\--wrap {
-  position: relative; }
+  position: relative; 
+}
   .\--page.\--index .\--wrap::before {
     content: '';
     height: 100%;
@@ -1637,7 +1639,8 @@ header.header-main {
     top: 0;
     position: absolute;
     background: #0e1012;
-    z-index: -1; }
+    z-index: -1; 
+  }
 
 .\--page-body {
   background: white; }


### PR DESCRIPTION
This fixes the too-small container on screens with large resolutions @jackparmer.

Before:
![Screen Shot 2021-09-14 at 6 01 14 PM](https://user-images.githubusercontent.com/52431501/133339866-9ca6fbff-5921-4c06-9917-af7b0a5a2b78.png)

After:
![Screen Shot 2021-09-14 at 6 00 59 PM](https://user-images.githubusercontent.com/52431501/133339882-9b948b95-5f93-431f-88ef-cbfb3ba4e2b4.png)
