### PR TITLE
Change ggplot2 snapshot page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             cp --parents 'javascript/line-and-scatter/index.html' '../snapshots'
             cp --parents 'ggplot2/index.html' '../snapshots'
             cp --parents 'ggplot2/getting-started/index.html' '../snapshots'
-            cp --parents 'ggplot2/2D-Histogram/index.html' '../snapshots'
+            cp --parents 'ggplot2/histograms/index.html' '../snapshots'
             cp --parents 'matlab/index.html' '../snapshots'
             cp --parents 'matlab/getting-started/index.html' '../snapshots'
             cp --parents 'matlab/graphing-multiple-chart-types/index.html' '../snapshots'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
             cp --parents 'javascript/line-and-scatter/index.html' '../snapshots'
             cp --parents 'ggplot2/index.html' '../snapshots'
             cp --parents 'ggplot2/getting-started/index.html' '../snapshots'
-            cp --parents 'ggplot2/geom_abline/index.html' '../snapshots'
+            cp --parents 'ggplot2/2D-Histogram/index.html' '../snapshots'
             cp --parents 'matlab/index.html' '../snapshots'
             cp --parents 'matlab/getting-started/index.html' '../snapshots'
             cp --parents 'matlab/graphing-multiple-chart-types/index.html' '../snapshots'


### PR DESCRIPTION
Now that the original page no longer exists, this PR updates the following snapshot link in the CI file from:

`cp --parents 'ggplot2/geom_abline/index.html' '../snapshots'`

to:

`cp --parents 'ggplot2/2D-Histogram/index.html' '../snapshots'`