### PR TITLE
Adding jekyll-seo plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 gem 'github-pages'
 gem 'jekyll-redirect-from'
+gem 'jekyll-seo-tag'
 gem 'jemoji'
 gem 'octopress'
 gem 'rake'

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 plugins:
 - jekyll-redirect-from
+- jekyll-seo-tag
 - jekyll-sitemap
 - algoliasearch-jekyll
 
@@ -63,3 +64,24 @@ algolia:
       - h6
       - unordered(text)
       - unordered(tags)
+
+# ---
+# Jekyll SEO Tags
+# ---
+url: https://plotly.com
+tagline: Plotly is the easiest way to graph and share your data
+author: plotlygraphs
+twitter:
+  username: plotlygraphs
+  card: photo
+facebook:
+  admin: 1123751525
+  admins: 22418
+logo: /all_static/images/dark-logo.png
+social:
+  links:
+    - https://twitter.com/plotlygraphs
+    - https://www.facebook.com/plotly
+    - https://www.linkedin.com/company/plotly/mycompany/
+    - https://github.com/plotly
+    - https://www.instagram.com/plotly/

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,5 +1,6 @@
 plugins:
   - jekyll-redirect-from
+  - jekyll-seo-tag
   - jekyll-sitemap
   - algoliasearch-jekyll
 
@@ -69,3 +70,24 @@ algolia:
       - h6
       - unordered(text)
       - unordered(tags)
+
+# ---
+# Jekyll SEO Tags
+# ---
+url: https://plotly.com
+tagline: Plotly is the easiest way to graph and share your data
+author: plotlygraphs
+twitter:
+  username: plotlygraphs
+  card: photo
+facebook:
+  admin: 1123751525
+  admins: 22418
+logo: /all_static/images/dark-logo.png
+social:
+  links:
+    - https://twitter.com/plotlygraphs
+    - https://www.facebook.com/plotly
+    - https://www.linkedin.com/company/plotly/mycompany/
+    - https://github.com/plotly
+    - https://www.instagram.com/plotly/

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-
+{% seo %}
 {% include layouts/head.html %}
 
 <body data-spy="scroll" data-target=".watch" style="position:relative;" class="darkmode">


### PR DESCRIPTION
This PR adds the jekyll-seo plugin to handle per-page SEO improvements, and default meta-tag behaviour. The seo flag is added above the header in the main site layout.  