### PR TITLE
Fix Typo On Continuous Error Bars

### DIFF
--- a/_posts/plotly_js/statistical/continuous-error-bars/2016-02-15-filled-lines.html
+++ b/_posts/plotly_js/statistical/continuous-error-bars/2016-02-15-filled-lines.html
@@ -33,7 +33,7 @@ var trace3 = {
   fill: "tozerox", 
   fillcolor: "rgba(231,107,243,0.2)", 
   line: {color: "transparent"}, 
-  name: "Fair", 
+  name: "Ideal", 
   showlegend: false, 
   type: "scatter"
 };


### PR DESCRIPTION
Match trace name for the "Ideal" error bars to the "Ideal" trace