### PR TITLE
Meta tag fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 gem 'github-pages'
 gem 'jekyll-redirect-from'
-gem 'jekyll-seo-tag'
 gem 'jemoji'
 gem 'octopress'
 gem 'rake'

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,5 @@
 plugins:
 - jekyll-redirect-from
-- jekyll-seo-tag
 - jekyll-sitemap
 - algoliasearch-jekyll
 
@@ -64,24 +63,3 @@ algolia:
       - h6
       - unordered(text)
       - unordered(tags)
-
-# ---
-# Jekyll SEO Tags
-# ---
-url: https://plotly.com
-tagline: Plotly is the easiest way to graph and share your data
-author: plotlygraphs
-twitter:
-  username: plotlygraphs
-  card: photo
-facebook:
-  admin: 1123751525
-  admins: 22418
-logo: /all_static/images/dark-logo.png
-social:
-  links:
-    - https://twitter.com/plotlygraphs
-    - https://www.facebook.com/plotly
-    - https://www.linkedin.com/company/plotly/mycompany/
-    - https://github.com/plotly
-    - https://www.instagram.com/plotly/

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,6 +1,5 @@
 plugins:
   - jekyll-redirect-from
-  - jekyll-seo-tag
   - jekyll-sitemap
   - algoliasearch-jekyll
 
@@ -70,24 +69,3 @@ algolia:
       - h6
       - unordered(text)
       - unordered(tags)
-
-# ---
-# Jekyll SEO Tags
-# ---
-url: https://plotly.com
-tagline: Plotly is the easiest way to graph and share your data
-author: plotlygraphs
-twitter:
-  username: plotlygraphs
-  card: photo
-facebook:
-  admin: 1123751525
-  admins: 22418
-logo: /all_static/images/dark-logo.png
-social:
-  links:
-    - https://twitter.com/plotlygraphs
-    - https://www.facebook.com/plotly
-    - https://www.linkedin.com/company/plotly/mycompany/
-    - https://github.com/plotly
-    - https://www.instagram.com/plotly/

--- a/_includes/layouts/seo.html
+++ b/_includes/layouts/seo.html
@@ -3,6 +3,7 @@
 {% capture title %}
     {% if page.permalink == '/python/' or page.language == '/julia/' or page.language == '/r/' or page.language == '/ggplot2/' or page.language == '/f_sharp/' or page.language == '/matlab/' or page.language == '/javascript/' %}{{page.name}}
     {% elsif page.name == '404' %} 404 Page Not Found
+    {% elsif page.permalink == '/api/' or page.permalink == '/graphing-libraries/' %} Plotly Open Source Graphing Libraries
     {% elsif page.name %} {{page.name | capitalize}} with {% if page.language == 'plotly_js' %}JavaScript{% elsif page.language == 'ggplot2'%}ggplot2{% elsif page.language == 'f_sharp' %}F#{% elsif page.language == 'matlab' %}MATLAB{% else %}{{page.language | capitalize }}{% endif %}{% else %} Plotly Open Source Graphing Libraries{% endif %}
 {% endcapture %}
 <!-- Count number of plots on the page -->
@@ -20,6 +21,8 @@
 
 {% if page.layout == 'langindex' %}
     {% capture description %}{{page.description}}{% endcapture %}
+{% elsif page.permalink == '/api/' or page.permalink == '/graphing-libraries/' %}
+    {% capture description %}"Interactive charts and maps for Python, R, Julia, Javascript, ggplot2, F#, MATLAB®, and Dash."{% endcapture %}
 {% else %}
     {% assign counter = 0 %}
     {% for code_block in code_blocks %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-{% seo %}
 {% include layouts/head.html %}
 
 <body data-spy="scroll" data-target=".watch" style="position:relative;" class="darkmode">


### PR DESCRIPTION
Closes #171 

This PR also removes the redundant meta tags from `jekyll-seo` in place of the interpolated language/page-specific ones. 

![image](https://user-images.githubusercontent.com/30986043/158676953-63f354b8-5097-4871-85bd-04ef90937190.png)
