### PR TITLE
indicator trace: remove the invalid "ticker" option

### DIFF
--- a/_posts/plotly_js/financial/indicator1/2019-07-29-above-other-traces.html
+++ b/_posts/plotly_js/financial/indicator1/2019-07-29-above-other-traces.html
@@ -15,7 +15,6 @@ var data = [
     mode: "number+delta",
     value: 492,
     delta: { reference: 512, valueformat: ".0f" },
-    ticker: { showticker: true },
     vmax: 500,
     domain: { y: [0, 1], x: [0.25, 0.75] },
     title: { text: "Users online" }


### PR DESCRIPTION
The `ticker` option is not valid for indicator charts. In fact, I did a full search over the https://github.com/plotly/plotly.js repo and didn't find any mention for that option anywhere (except for being present in the automated test for this example/post)

Related PR: https://github.com/plotly/plotly.js/pull/6224

EDIT: seems like `vmax` is also invalid for indicator charts...