### PR TITLE
Updating favicon url

### DIFF
--- a/_includes/layouts/head.html
+++ b/_includes/layouts/head.html
@@ -113,7 +113,7 @@
   <!--<link rel="stylesheet" type="text/css" href="http://api.plotly.dev/all_static/css/main.css">-->
 
   <!-- Icon -->
-  <link rel="shortcut icon" href="https://plotly.com/img/favicon.ico" />
+  <link rel="shortcut icon" href="https://plotly.com/favicon_new.svg" />
 
   <!-- Google Tags-->
   {% include layouts/google-tag-head.html %}


### PR DESCRIPTION
Updates the favicon URL to point to the one used on the `plotly.com` marketing website. 