### PR TITLE
Fix forum links

### DIFF
--- a/_includes/layouts/_header-main.html
+++ b/_includes/layouts/_header-main.html
@@ -9,7 +9,7 @@
         <li><a style="font-weight: bold;"
                 href="https://community.plotly.com/c/{% if page.permalink contains 'javascript' %}plotly-js/6{% elsif page.permalink contains 'python' %}plotly-python/5{% else %}plotly-r-matlab-julia-net/29{% endif %}">Forum</a>
         </li>
-        <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing/">aPricing</a></li>
+        <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing/">Pricing</a></li>
         <li><a style="font-weight: bold;" href="https://dash.plotly.com">Dash</a></li>
         <!--<li><a style="font-weight: bold;" href="http://plotly.cloud">Dash Cloud</a></li>-->
 

--- a/_includes/layouts/_header-main.html
+++ b/_includes/layouts/_header-main.html
@@ -7,7 +7,7 @@
     <div class="close-menu"></div>
     <ul>
         <li><a style="font-weight: bold;"
-                href="https://community.plotly.com/c/{% if page.permalink contains 'javascript' %}plotly-js/6{% elsif page.permalink contains 'python' %}plotly-python/5{% else %}plotly-r-matlab-julia-net/29{% endif %}">Forum</a>
+                href="https://community.plotly.com/c/{% if page.permalink contains 'javascript' %}plotly-js/6{% elsif page.permalink contains 'python' %}plotly-python/5{% elsif page.permalink contains 'r/' or page.permalink contains 'ggplot2/' or page.permalink contains 'matlab/' or page.permalink contains 'fsharp/' or page.permalink contains 'julia/' %}plotly-r-matlab-julia-net/29{% else %}{% endif %}">Forum</a>
         </li>
         <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing/">Pricing</a></li>
         <li><a style="font-weight: bold;" href="https://dash.plotly.com">Dash</a></li>
@@ -133,7 +133,7 @@
 
                         </li>
                         <li><a style="font-weight: bold;"
-                                href="https://community.plotly.com/c/{% if page.permalink contains 'javascript' %}plotly-js/6{% elsif page.permalink contains 'python' %}plotly-python/5{% else %}plotly-r-matlab-julia-net/29{% endif %}">Forum</a>
+                                href="https://community.plotly.com/c/{% if page.permalink contains 'javascript' %}plotly-js/6{% elsif page.permalink contains 'python' %}plotly-python/5{% elsif page.permalink contains 'r/' or page.permalink contains 'ggplot2/' or page.permalink contains 'matlab/' or page.permalink contains 'fsharp/' or page.permalink contains 'julia/' %}plotly-r-matlab-julia-net/29{% else %}{% endif %}">Forum</a>
                         </li>
                         <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing/">Pricing</a></li>
                         <li><a style="font-weight: bold;" href="https://dash.plotly.com">Dash</a></li>

--- a/_includes/layouts/_header-main.html
+++ b/_includes/layouts/_header-main.html
@@ -7,9 +7,9 @@
     <div class="close-menu"></div>
     <ul>
         <li><a style="font-weight: bold;"
-                href="https://community.plotly.com/c/graphing-libraries/{% if page.permalink contains 'javascript' %}javascript{% elsif page.permalink contains 'fsharp' %}net{% elsif page.permalink contains 'csharp' %}net{% else %}{{page.language}}{% endif %}">Forum</a>
+                href="https://community.plotly.com/c/{% if page.permalink contains 'javascript' %}plotly-js/6{% elsif page.permalink contains 'python' %}plotly-python/5{% else %}plotly-r-matlab-julia-net/29{% endif %}">Forum</a>
         </li>
-        <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing/">Pricing</a></li>
+        <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing/">aPricing</a></li>
         <li><a style="font-weight: bold;" href="https://dash.plotly.com">Dash</a></li>
         <!--<li><a style="font-weight: bold;" href="http://plotly.cloud">Dash Cloud</a></li>-->
 
@@ -133,7 +133,7 @@
 
                         </li>
                         <li><a style="font-weight: bold;"
-                                href="https://community.plotly.com/c/graphing-libraries/{% if page.permalink contains 'javascript' %}javascript{% elsif page.permalink contains 'fsharp' %}net{% elsif page.permalink contains 'csharp' %}net{% else %}{{page.language}}{% endif %}">Forum</a>
+                                href="https://community.plotly.com/c/{% if page.permalink contains 'javascript' %}plotly-js/6{% elsif page.permalink contains 'python' %}plotly-python/5{% else %}plotly-r-matlab-julia-net/29{% endif %}">Forum</a>
                         </li>
                         <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing/">Pricing</a></li>
                         <li><a style="font-weight: bold;" href="https://dash.plotly.com">Dash</a></li>


### PR DESCRIPTION
The forum links currently throw an "Oops! That page doesn’t exist or is private." error.

This updates the links to the following:

**Python:** https://community.plotly.com/c/plotly-python/5
**JS :** https://community.plotly.com/c/plotly-js/6
**Other languages:** https://community.plotly.com/c/plotly-r-matlab-julia-net/29

@Coding-with-Adam

