### PR TITLE
Fix Julia "suggest an edit" links

### DIFF
--- a/_includes/layouts/breadcrumb.html
+++ b/_includes/layouts/breadcrumb.html
@@ -73,7 +73,7 @@
             {% assign filename = page.path %}
             <a id="forklink" href= "{{ filename | prepend: "https://github.com/plotly/graphing-library-docs/edit/master/" }}" >
         {% elsif page.path contains "/julia/" %}
-            {% assign filename = page.path %}
+            {% assign filename = page.path | replace: "_posts/julia/html/2021-08-17-", "" | replace: ".html", ".md" %}
             <a id="forklink" href= "{{ filename | prepend: "https://github.com/plotly/plotlyjs.jl-docs/edit/master/julia/" }}" >
         {% elsif page.path contains "/fsharp/" %}
             {% assign filename = page.path %}


### PR DESCRIPTION
The "Suggest an edit" links don't go to a page on Github.

Looks like we are not constructing the link correctly. Just wanted to confirm @nicolaskruchten, it is those .md files that the the eventual HTML files for the Julia pages are built off of?

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/12749831/211639277-803afceb-4422-4937-abc7-9544b0936544.png">
