### PR TITLE
Escape backslashes so that they make it to MathJax

### DIFF
--- a/_posts/plotly_js/fundamentals/latex/2015-04-09-latex.html
+++ b/_posts/plotly_js/fundamentals/latex/2015-04-09-latex.html
@@ -10,18 +10,18 @@ sitemap: false
 var trace1 = {
   x: [1, 2, 3, 4],
   y: [1, 4, 9, 16],
-  name: '$\alpha_{1c} = 352 \pm 11 \text{ km s}^{-1}$',
+  name: '$\\alpha_{1c} = 352 \\pm 11 \\text{ km s}^{-1}$',
   type: 'scatter'
 };
 var trace2 = {
   x: [1, 2, 3, 4],
   y: [0.5, 2, 4.5, 8],
-  name: '$\beta_{1c} = 25 \pm 11 \text{ km s}^{-1}$',
+  name: '$\\beta_{1c} = 25 \\pm 11 \\text{ km s}^{-1}$',
   type: 'scatter'
 };
 var data = [trace1, trace2];
 var layout = {
-  xaxis: {title: '$\sqrt{(n_\text{c}(t|{T_\text{early}}))}$'},
-  yaxis: {title: '$d, r \text{ (solar radius)}$'}
+  xaxis: {title: '$\\sqrt{(n_\\text{c}(t|{T_\\text{early}}))}$'},
+  yaxis: {title: '$d, r \\text{ (solar radius)}$'}
 };
 Plotly.newPlot('myDiv', data, layout);


### PR DESCRIPTION
Without the escapes, the LaTeX doesn't render properly, as can be seen by following the link to codepen from [the docs](https://plotly.com/javascript/LaTeX/).