### PR TITLE
Fix section links in reference homepage

### DIFF
--- a/_posts/reference_pages/2015-08-19-plotly_js-reference.html
+++ b/_posts/reference_pages/2015-08-19-plotly_js-reference.html
@@ -22,33 +22,33 @@ redirect_from: /javascript-graphing-library/reference/
     <pre>
     data = [
         {
-            type: 'scatter',  // all "scatter" attributes: <a href="#scatter">https://plotly.com/javascript/reference/#scatter</a>
-            x: [1, 2, 3],     // more about "x": <a href="#scatter-x">#scatter-x</a>
-            y: [3, 1, 6],     // <a href="#scatter-y">#scatter-y</a>
-            marker: {         // marker is an object, valid marker keys: <a href="#scatter-marker">#scatter-marker</a>
-                color: 'rgb(16, 32, 77)' // more about "marker.color": <a href="#scatter-marker-color">#scatter-marker-color</a>
+            type: 'scatter',  // all "scatter" attributes: <a href="../#scatter">#scatter</a>
+            x: [1, 2, 3],     // more about "x": <a href="../#scatter-x">#scatter-x</a>
+            y: [3, 1, 6],     // <a href="../#scatter-y">#scatter-y</a>
+            marker: {         // marker is an object, valid marker keys: <a href="../#scatter-marker">#scatter-marker</a>
+                color: 'rgb(16, 32, 77)' // more about "marker.color": <a href="../#scatter-marker-color">#scatter-marker-color</a>
             }
         },
         {
-            type: 'bar',      // all "bar" chart attributes: <a href="#bar">#bar</a>
-            x: [1, 2, 3],     // more about "x": <a href="#bar-x">#bar-x</a>
-            y: [3, 1, 6],     // <a href="#bar-y">#bar-y</a>
-            name: 'bar chart example' // <a href="#bar-name">#bar-name</a>
+            type: 'bar',      // all "bar" chart attributes: <a href="../#bar">#bar</a>
+            x: [1, 2, 3],     // more about "x": <a href="../#bar-x">#bar-x</a>
+            y: [3, 1, 6],     // <a href="../#bar-y">#bar-y</a>
+            name: 'bar chart example' // <a href="../#bar-name">#bar-name</a>
         }
     ];
 
-    layout = {                     // all "layout" attributes: <a href="#layout">#layout</a>
-        title: 'simple example',  // more about "layout.title": <a href="#layout-title">#layout-title</a>
-        xaxis: {                  // all "layout.xaxis" attributes: <a href="#layout-xaxis">#layout-xaxis</a>
-            title: 'time'         // more about "layout.xaxis.title": <a href="#layout-xaxis-title">#layout-xaxis-title</a>
+    layout = {                     // all "layout" attributes: <a href="../#layout">#layout</a>
+        title: 'simple example',  // more about "layout.title": <a href="../#layout-title">#layout-title</a>
+        xaxis: {                  // all "layout.xaxis" attributes: <a href="../#layout-xaxis">#layout-xaxis</a>
+            title: 'time'         // more about "layout.xaxis.title": <a href="../#layout-xaxis-title">#layout-xaxis-title</a>
         },
-        annotations: [            // all "annotation" attributes: <a href="#layout-annotations">#layout-annotations</a>
+        annotations: [            // all "annotation" attributes: <a href="../#layout-annotations">#layout-annotations</a>
             {
-                text: 'simple annotation',    // <a href="#layout-annotations-text">#layout-annotations-text</a>
-                x: 0,                         // <a href="#layout-annotations-x">#layout-annotations-x</a>
-                xref: 'paper',                // <a href="#layout-annotations-xref">#layout-annotations-xref</a>
-                y: 0,                         // <a href="#layout-annotations-y">#layout-annotations-y</a>
-                yref: 'paper'                 // <a href="#layout-annotations-yref">#layout-annotations-yref</a>
+                text: 'simple annotation',    // <a href="../#layout-annotations-text">#layout-annotations-text</a>
+                x: 0,                         // <a href="../#layout-annotations-x">#layout-annotations-x</a>
+                xref: 'paper',                // <a href="../#layout-annotations-xref">#layout-annotations-xref</a>
+                y: 0,                         // <a href="../#layout-annotations-y">#layout-annotations-y</a>
+                yref: 'paper'                 // <a href="../#layout-annotations-yref">#layout-annotations-yref</a>
             }
         ]
     }</pre>


### PR DESCRIPTION
Hi team, thank you so much for putting together this amazing library and docs. It's been greatly beneficial for me.

## Issue Description:

While navigating through docs, I found some broken links and wanted to suggest changes on them.

Affected page: https://plotly.com/javascript/reference/index

## Issue Demo:
<picture>
  <img width="600" src="https://github.com/plotly/graphing-library-docs/assets/36477517/ef013f5b-79fc-4631-a3dc-42d8f18994eb" alt="Issue Demo GIF" />
</picture>

## Solution Demo:
Capturing demo by making local html changes through browser dev tools.

<picture>
   <img width="600" src="https://github.com/plotly/graphing-library-docs/assets/36477517/eb12cc5d-c358-4ad2-aa42-3fd16e07eb6d" alt="Solution Demo GIF"/>
</picture>