### PR TITLE
fix typo in `Add Buttons to ModeBar` example code

### DIFF
--- a/_posts/plotly_js/fundamentals/config-options/2020-01-24-add-button-to-modebar.html
+++ b/_posts/plotly_js/fundamentals/config-options/2020-01-24-add-button-to-modebar.html
@@ -24,11 +24,11 @@ var data = [{
 var layout = {
   title: {
     text: 'add mode bar button with custom icon'
-  },
-  modebardisplay: false
+  }
 }
 
 var config = {
+  displayModeBar: true,
   modeBarButtonsToAdd: [
     {
       name: 'color toggler',


### PR DESCRIPTION
Fix typo in 
https://plotly.com/javascript/configuration-options/#add-buttons-to-modebar

The `modebardisplay` should be put in `config` instead of `layout`, but the name is actually wrong. It should be `displayModeBar`.

And since this example shows how to add a custom button, it is pointless to disable it.

I set it to `true` so the modebar is always visible, but it is optional.