### PR TITLE
Fix tickmode JavaScript syntax in examples

### DIFF
--- a/_posts/plotly_js/basic/dot/2015-08-11-categorical-dot-plot.html
+++ b/_posts/plotly_js/basic/dot/2015-08-11-categorical-dot-plot.html
@@ -63,7 +63,7 @@ var layout = {
         color: 'rgb(102, 102, 102)'
       }
     },
-    tickmode: linear,
+    tickmode: 'linear',
     dtick: 10,
     ticks: 'outside',
     tickcolor: 'rgb(102, 102, 102)'

--- a/_posts/plotly_js/basic/line-plots/2015-08-07-labelling-with-annotations.html
+++ b/_posts/plotly_js/basic/line-plots/2015-08-07-labelling-with-annotations.html
@@ -64,7 +64,7 @@ var layout = {
     showticklabels: true,
     linecolor: 'rgb(204,204,204)',
     linewidth: 2,
-    tickmode: linear,
+    tickmode: 'linear',
     ticks: 'outside',
     tickcolor: 'rgb(204,204,204)',
     tickwidth: 2,

--- a/_posts/plotly_js/fundamentals/axes/2015-04-09-axes-ticks.html
+++ b/_posts/plotly_js/fundamentals/axes/2015-04-09-axes-ticks.html
@@ -19,7 +19,7 @@ var trace2 = {
 var data = [trace1, trace2];
 var layout = {
   xaxis: {
-    tickmode: linear,
+    tickmode: 'linear',
     ticks: 'outside',
     tick0: 0,
     dtick: 0.25,
@@ -28,7 +28,7 @@ var layout = {
     tickcolor: '#000'
   },
   yaxis: {
-    tickmode: linear,
+    tickmode: 'linear',
     ticks: 'outside',
     tick0: 0,
     dtick: 0.25,

--- a/_posts/plotly_js/fundamentals/colorscales/2015-08-10-discretized-heatmap-colorscale.html
+++ b/_posts/plotly_js/fundamentals/colorscales/2015-08-10-discretized-heatmap-colorscale.html
@@ -52,7 +52,7 @@ var data = [
     ],
     type: 'heatmap',
     colorbar:{
-      tickmode: linear,
+      tickmode: 'linear',
       tick0: 0,
       dtick: 1
     }

--- a/_posts/plotly_js/fundamentals/images/2016-06-21-logo.html
+++ b/_posts/plotly_js/fundamentals/images/2016-06-21-logo.html
@@ -54,7 +54,7 @@ var layout = {
   },
   width: 700,
   xaxis: {
-    tickmode: linear,
+    tickmode: "linear",
     dtick: 10,
     gridcolor: "rgba(102, 102, 102, 0.4)",
     linecolor: "#000",
@@ -70,7 +70,7 @@ var layout = {
   },
   yaxis: {
     anchor: "x",
-    tickmode: linear,
+    tickmode: "linear",
     gridcolor: "rgba(102, 102, 102, 0.4)",
     gridwidth: 1,
     linecolor: "#000",

--- a/_posts/plotly_js/fundamentals/shapes/2015-08-10-venn-diagram-with-circle-shapes.html
+++ b/_posts/plotly_js/fundamentals/shapes/2015-08-10-venn-diagram-with-circle-shapes.html
@@ -26,13 +26,13 @@ var layout = {
   },
   xaxis: {
     showticklabels: false,
-    tickmode: linear,
+    tickmode: 'linear',
     showgrid: false,
     zeroline: false
   },
   yaxis: {
     showticklabels: false,
-    tickmode: linear,
+    tickmode: 'linear',
     showgrid: false,
     zeroline: false
   },


### PR DESCRIPTION
Without that, some example plots cannot be rendered properly (e. g. <https://plotly.com/javascript/dot-plots/#categorical-dot-plot>).

Looks like this problem was introduced in pull request <https://github.com/plotly/graphing-library-docs/pull/328>.