### PR TITLE
Escape backslashes so that they make it to MathJax

### DIFF
--- a/_posts/plotly_js/fundamentals/latex/2015-04-09-latex.html
+++ b/_posts/plotly_js/fundamentals/latex/2015-04-09-latex.html
@@ -10,25 +10,25 @@ sitemap: false
 var trace1 = {
   x: [1, 2, 3, 4],
   y: [1, 4, 9, 16],
-  name: '$\alpha_{1c} = 352 \pm 11 \text{ km s}^{-1}$',
+  name: '$\\alpha_{1c} = 352 \\pm 11 \\text{ km s}^{-1}$',
   type: 'scatter'
 };
 var trace2 = {
   x: [1, 2, 3, 4],
   y: [0.5, 2, 4.5, 8],
-  name: '$\beta_{1c} = 25 \pm 11 \text{ km s}^{-1}$',
+  name: '$\\beta_{1c} = 25 \\pm 11 \\text{ km s}^{-1}$',
   type: 'scatter'
 };
 var data = [trace1, trace2];
 var layout = {
   xaxis: {
     title: {
-      text: '$\sqrt{(n_\text{c}(t|{T_\text{early}}))}$'
+      text: '$\\sqrt{(n_\\text{c}(t|{T_\\text{early}}))}$'
     }
   },
   yaxis: {
     title: {
-      text: '$d, r \text{ (solar radius)}$'
+      text: '$d, r \\text{ (solar radius)}$'
     }
   }
 };


### PR DESCRIPTION
Without the escapes, JavaScript interprets the backslashes as starting escape sequences, and the LaTeX fails to render properly, as can be seen by looking at [the docs](https://plotly.com/javascript/LaTeX/).  For example, '\sqrt' shows up as *sqrt* in the x-axis; it should be an actual square-root sign.

We just want backslashes passed through to LaTeX, so this PR escapes the backslashes.  It renders properly, as can be verified by pasting into [codepen](https://codepen.io/moble/pen/LEPXeeM).