### PR TITLE
Fix Sankey example to use `title.text` instead of `title`

### DIFF
--- a/_posts/plotly_js/basic/sankey/2019-11-20-nodes-position.html
+++ b/_posts/plotly_js/basic/sankey/2019-11-20-nodes-position.html
@@ -24,7 +24,11 @@ var data = [{
         value: [1, 2, 1, 1, 1, 1, 1, 2]}
     }]
 
-var layout = {"title": "Sankey with manually positioned node"}
+var layout = {
+  title: {
+    text: "Sankey with manually positioned node"
+  }
+}
 
 Plotly.newPlot('myDiv', data, layout)
 


### PR DESCRIPTION
Without that adjustment, one of the examples does not render the title. See <https://plotly.com/javascript/sankey-diagram/#define-node-position>. The possibility to just use `title` instead of `title.text` to set a plot's title was removed in Plotly.js 3.0.0.