### PR TITLE
Fixes typos in migration to v3 guide

### DIFF
--- a/_posts/plotly_js/fundamentals/plotly-js-3-changes/2024-10-09-plotly-js-3-changes.md
+++ b/_posts/plotly_js/fundamentals/plotly-js-3-changes/2024-10-09-plotly-js-3-changes.md
@@ -21,7 +21,7 @@ Plotly.js 3 removes the following features that were deprecated in previous vers
 
 `annotation.ref` has been removed. Use `annotation.xref` and `annotation.yref` instead.
 
-Here's an example using `annotation.ref`, followed by teh same example rewritte to use `annotation.xref` and `annotation.yref`:
+Here's an example using `annotation.ref`, followed by the same example rewritten to use `annotation.xref` and `annotation.yref`:
 
 ```js
 ...


### PR DESCRIPTION
Fixes 2 typos
- teh -> the
- writte -> written