### PR TITLE
docs: Fix config for JS choropleth example

### DIFF
--- a/_posts/plotly_js/maps/choropleth-maps/2015-08-10-countrygdp-choropleth-map.html
+++ b/_posts/plotly_js/maps/choropleth-maps/2015-08-10-countrygdp-choropleth-map.html
@@ -27,10 +27,10 @@ d3.csv('https://raw.githubusercontent.com/plotly/datasets/master/2014_world_gdp_
                 width: 0.5
             }
         },
-        tick0: 0,
         zmin: 0,
-        dtick: 1000,
         colorbar: {
+            dtick: 1000,
+            tick0: 0,
             tickmode: 'linear',
             tickprefix: '$',
             title: {text: 'GDP<br>Billions US$'}


### PR DESCRIPTION
### Description

Fix config for JS choropleth example.

### Notes

- The wrong config resulted in plotly.js to try to draw billions of ticks on the colorbar
- There were a couple of bugs in the config dating back to 2020
- I fixed one in a recent update and that caused the lag
- This change fixes the other bug and removes the lag. 18 ticks instead of billions.