### PR TITLE
Update DE links to marketing site

### DIFF
--- a/_includes/layouts/_footer-main.html
+++ b/_includes/layouts/_footer-main.html
@@ -23,7 +23,7 @@
             &#x9;&#x9;&#x9;&#x9;
             <li><a href="https://plotly.com/cloud?utm_source=graphing_libraries&utm_medium=documentation&utm_campaign=studio_cloud_community&utm_content=footer" target="_self">Plotly Cloud</a></li>
             &#x9;&#x9;&#x9;&#x9;
-            <li><a href="https://plotly.com/dash/?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">Dash Enterprise</a></li>
+            <li><a href="https://plotly.com/dash-enterprise/?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">Dash Enterprise</a></li>
             &#x9;&#x9;&#x9;&#x9;
             <li><a href="https://plotly.com/whats-new/?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">New Releases →</a></li>
           </ul>

--- a/_posts/ggplot2/other_pages/2021-08-04-is-plotly-free.md
+++ b/_posts/ggplot2/other_pages/2021-08-04-is-plotly-free.md
@@ -26,5 +26,5 @@ obtaining any token, or creating any account.
 
 #### Does Plotly also make commercial software?
 
-&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash).
+&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash-enterprise).
 

--- a/_posts/matlab/other_pages/2021-08-04-is-plotly-free.md
+++ b/_posts/matlab/other_pages/2021-08-04-is-plotly-free.md
@@ -26,5 +26,5 @@ obtaining any token, or creating any account.
 
 #### Does Plotly also make commercial software?
 
-&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash).
+&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash-enterprise).
 

--- a/_posts/plotly_js/2019-07-03-is-plotly-free-js.md
+++ b/_posts/plotly_js/2019-07-03-is-plotly-free-js.md
@@ -30,4 +30,4 @@ which use tiles from a cloud-hosted service, such as Open Street Maps or Mapbox,
 
 #### Does Plotly also make commercial software?
 
-&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash).
+&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash-enterprise).

--- a/_posts/python/2019-07-03-3d-index.html
+++ b/_posts/python/2019-07-03-3d-index.html
@@ -38,7 +38,7 @@ thumbnail: thumbnail/mixed.jpg
   <div>
     <h3 id="statistic-in-dash">3D Charts in Dash</h3>
     <p><a href="https://plotly.com/dash/">Dash</a> is the best way to build analytical apps in Python using Plotly figures. To run the app below, run <code>pip install dash</code>, click "Download" to get the code and run <code>python app.py</code>.</p>
-    <p>Get started with <a href="https://dash.plotly.com/installation">the official Dash docs</a> and <strong>learn how to effortlessly <a href="https://plotly.com/dash/design-kit/">style</a> &amp; <a href="https://plotly.com/dash/app-manager/">deploy</a> apps like this with <a class="plotly-red" href="https://plotly.com/dash/">Dash Enterprise</a>.</strong></p>
+    <p>Get started with <a href="https://dash.plotly.com/installation">the official Dash docs</a> and <strong>learn how to effortlessly <a href="https://plotly.com/dash/design-kit/">style</a> &amp; <a href="https://plotly.com/dash/app-manager/">deploy</a> apps like this with <a class="plotly-red" href="https://plotly.com/dash-enterprise/">Dash Enterprise</a>.</strong></p>
   </div>
 </div>
 

--- a/_posts/python/2019-07-03-fundamentals-index.html
+++ b/_posts/python/2019-07-03-fundamentals-index.html
@@ -36,7 +36,7 @@ page_type: example_index
   <div>
     <h3 id="fundamentals-in-dash">Plotly Express in Dash</h3>
     <p><a href="https://plotly.com/dash/">Dash</a> is the best way to build analytical apps in Python using Plotly figures. To run the app below, run <code>pip install dash</code>, click "Download" to get the code and run <code>python app.py</code>.</p>
-    <p>Get started with <a href="https://dash.plotly.com/installation">the official Dash docs</a> and <strong>learn how to effortlessly <a href="https://plotly.com/dash/design-kit/">style</a> &amp; <a href="https://plotly.com/dash/app-manager/">deploy</a> apps like this with <a class="plotly-red" href="https://plotly.com/dash/">Dash Enterprise</a>.</strong></p>
+    <p>Get started with <a href="https://dash.plotly.com/installation">the official Dash docs</a> and <strong>learn how to effortlessly <a href="https://plotly.com/dash/design-kit/">style</a> &amp; <a href="https://plotly.com/dash/app-manager/">deploy</a> apps like this with <a class="plotly-red" href="https://plotly.com/dash-enterprise/">Dash Enterprise</a>.</strong></p>
   </div>
 </div>
 

--- a/_posts/python/2019-07-03-is-plotly-free.md
+++ b/_posts/python/2019-07-03-is-plotly-free.md
@@ -25,5 +25,5 @@ language: python
 
 #### Does Plotly also make commercial software?
 
-&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash), [Plotly Studio](https://plotly.com/studio), and [Plotly Cloud](https://plotly.com/cloud).
+&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash-enterprise), [Plotly Studio](https://plotly.com/studio), and [Plotly Cloud](https://plotly.com/cloud).
 

--- a/_posts/python/2019-07-03-maps-index.html
+++ b/_posts/python/2019-07-03-maps-index.html
@@ -35,7 +35,7 @@ page_type: example_index
   <div>
     <h3 id="choropleth-maps-in-dash">Maps in Dash</h3>
     <p><a href="https://plotly.com/dash/">Dash</a> is the best way to build analytical apps in Python using Plotly figures. To run the app below, run <code>pip install dash</code>, click "Download" to get the code and run <code>python app.py</code>.</p>
-    <p>Get started with <a href="https://dash.plotly.com/installation">the official Dash docs</a> and <strong>learn how to effortlessly <a href="https://plotly.com/dash/design-kit/">style</a> &amp; <a href="https://plotly.com/dash/app-manager/">deploy</a> apps like this with <a class="plotly-red" href="https://plotly.com/dash/">Dash Enterprise</a>.</strong></p>
+    <p>Get started with <a href="https://dash.plotly.com/installation">the official Dash docs</a> and <strong>learn how to effortlessly <a href="https://plotly.com/dash/design-kit/">style</a> &amp; <a href="https://plotly.com/dash/app-manager/">deploy</a> apps like this with <a class="plotly-red" href="https://plotly.com/dash-enterprise/">Dash Enterprise</a>.</strong></p>
   </div>
 </div>
 

--- a/_posts/python/2019-07-03-statistic-index.html
+++ b/_posts/python/2019-07-03-statistic-index.html
@@ -35,7 +35,7 @@ page_type: example_index
   <div>
     <h3 id="statistic-in-dash">Statistical charts in Dash</h3>
     <p><a href="https://plotly.com/dash/">Dash</a> is the best way to build analytical apps in Python using Plotly figures. To run the app below, run <code>pip install dash</code>, click "Download" to get the code and run <code>python app.py</code>.</p>
-    <p>Get started with <a href="https://dash.plotly.com/installation">the official Dash docs</a> and <strong>learn how to effortlessly <a href="https://plotly.com/dash/design-kit/">style</a> &amp; <a href="https://plotly.com/dash/app-manager/">deploy</a> apps like this with <a class="plotly-red" href="https://plotly.com/dash/">Dash Enterprise</a>.</strong></p>
+    <p>Get started with <a href="https://dash.plotly.com/installation">the official Dash docs</a> and <strong>learn how to effortlessly <a href="https://plotly.com/dash/design-kit/">style</a> &amp; <a href="https://plotly.com/dash/app-manager/">deploy</a> apps like this with <a class="plotly-red" href="https://plotly.com/dash-entperise/">Dash Enterprise</a>.</strong></p>
   </div>
 </div>
 

--- a/_posts/r/2019-07-03-is-plotly-free-r.md
+++ b/_posts/r/2019-07-03-is-plotly-free-r.md
@@ -29,6 +29,6 @@ which use tiles from a cloud-hosted service, such as Open Street Maps or Mapbox,
 
 #### Does Plotly also make commercial software?
 
-&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash).
+&nbsp;  &nbsp; **Yes.** &nbsp; Plotly has commercial offerings such as [Dash Enterprise](https://plotly.com/dash-enterprise).
 
 


### PR DESCRIPTION
The marketing site now has `http://plotly.com/dash-enterprise`, so this PR updates links for DE that previously went to `http://plotly.com/dash`.