### PR TITLE
Revise UTMs to not override organic traffic data

### DIFF
--- a/_includes/layouts/_footer-main.html
+++ b/_includes/layouts/_footer-main.html
@@ -9,7 +9,7 @@
             <li>
               <p class="subscribe-text"> Sign up to stay in the loop with all things Plotly — from Dash Club to product
                 updates, webinars, and more!</p>
-              <a href="https://plotly.com/newsletter/?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" class="subscribe-button" target="_blank">
+              <a href="https://plotly.com/newsletter/?source=graphing_libraries&medium=documentation&content=footer" class="subscribe-button" target="_blank">
                 Subscribe
               </a>
             </li>
@@ -19,22 +19,22 @@
         <li class="--footer-column">
           <h6 style="color:#e763fa" class="--footer-heading">Products</h6>&#x9;&#x9;&#x9;
           <ul>
-            <li><a href="https://plotly.com/studio?utm_source=graphing_libraries&utm_medium=documentation&utm_campaign=studio_cloud_community&utm_content=footer" target="_self">Plotly Studio</a></li>
+            <li><a href="https://plotly.com/studio?source=graphing_libraries&medium=documentation&campaign=studio_cloud_community&content=footer" target="_self">Plotly Studio</a></li>
             &#x9;&#x9;&#x9;&#x9;
-            <li><a href="https://plotly.com/cloud?utm_source=graphing_libraries&utm_medium=documentation&utm_campaign=studio_cloud_community&utm_content=footer" target="_self">Plotly Cloud</a></li>
+            <li><a href="https://plotly.com/cloud?source=graphing_libraries&medium=documentation&campaign=studio_cloud_community&content=footer" target="_self">Plotly Cloud</a></li>
             &#x9;&#x9;&#x9;&#x9;
-            <li><a href="https://plotly.com/dash-enterprise/?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">Dash Enterprise</a></li>
+            <li><a href="https://plotly.com/dash-enterprise/?source=graphing_libraries&medium=documentation&content=footer" target="_self">Dash Enterprise</a></li>
             &#x9;&#x9;&#x9;&#x9;
-            <li><a href="https://plotly.com/whats-new/?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">New Releases →</a></li>
+            <li><a href="https://plotly.com/whats-new/?source=graphing_libraries&medium=documentation&content=footer" target="_self">New Releases →</a></li>
           </ul>
         </li>
         &#x9;&#x9;
         <li class="--footer-column">
           <h6 style="color:#636efa" class="--footer-heading">Pricing</h6>&#x9;&#x9;&#x9;
           <ul>
-            <li><a href="https://plotly.com/pricing?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">Studio and Cloud Pricing</a></li>
+            <li><a href="https://plotly.com/pricing?source=graphing_libraries&medium=documentation&content=footer" target="_self">Studio and Cloud Pricing</a></li>
             &#x9;&#x9;&#x9;&#x9;
-            <li><a href="https://plotly.com/get-pricing?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">Dash Enterprise Pricing</a></li>
+            <li><a href="https://plotly.com/get-pricing?source=graphing_libraries&medium=documentation&content=footer" target="_self">Dash Enterprise Pricing</a></li>
             &#x9;&#x9;&#x9;&#x9;
           </ul>
         </li>
@@ -42,11 +42,11 @@
         <li class="--footer-column">
           <h6 style="color:#00cc96" class="--footer-heading">About Us</h6>&#x9;&#x9;&#x9;
           <ul>
-            <li><a href="https://plotly.com/careers?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">Careers</a></li>
+            <li><a href="https://plotly.com/careers?source=graphing_libraries&medium=documentation&content=footer" target="_self">Careers</a></li>
             &#x9;&#x9;&#x9;&#x9;
-            <li><a href="https://plotly.com/resources/?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">Resources</a></li>
+            <li><a href="https://plotly.com/resources/?source=graphing_libraries&medium=documentation&content=footer" target="_self">Resources</a></li>
             &#x9;&#x9;&#x9;&#x9;
-            <li><a href="https://plotly.com/blog/?utm_source=graphing_libraries&utm_medium=documentation&utm_content=footer" target="_self">Blog</a></li>
+            <li><a href="https://plotly.com/blog/?source=graphing_libraries&medium=documentation&content=footer" target="_self">Blog</a></li>
             &#x9;&#x9;&#x9;&#x9;
           </ul>
         </li>

--- a/_includes/layouts/_header-main.html
+++ b/_includes/layouts/_header-main.html
@@ -6,9 +6,9 @@
     </div>
     <div class="close-menu"></div>
     <ul>
-        <li><a class="download-studio-btn" style="display: inline-block; font-weight: bold; background: #7A76FF; color: white !important; padding: 8px 16px; border-radius: 8px; text-decoration: none; transition: background 0.3s ease;" href="https://plotly.com/studio?utm_source=graphing_libraries&utm_medium=documentation&utm_campaign=studio_cloud_community&utm_content=header">Download Studio</a></li>
-        <li><a style="font-weight: bold;" href="https://plotly.com/pricing?utm_source=graphing_libraries&utm_medium=documentation&utm_content=header">Studio and Cloud Pricing</a></li>
-        <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing?utm_source=graphing_libraries&utm_medium=documentation&utm_content=header">Dash Enterprise Pricing</a></li>
+        <li><a class="download-studio-btn" style="display: inline-block; font-weight: bold; background: #7A76FF; color: white !important; padding: 8px 16px; border-radius: 8px; text-decoration: none; transition: background 0.3s ease;" href="https://plotly.com/studio?source=graphing_libraries&medium=documentation&campaign=studio_cloud_community&content=header">Download Studio</a></li>
+        <li><a style="font-weight: bold;" href="https://plotly.com/pricing?source=graphing_libraries&medium=documentation&content=header">Studio and Cloud Pricing</a></li>
+        <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing?source=graphing_libraries&medium=documentation&content=header">Dash Enterprise Pricing</a></li>
         <!--<li><a style="font-weight: bold;" href="http://plotly.cloud">Dash Cloud</a></li>-->
 
     </ul>
@@ -125,9 +125,9 @@
                             </ul>
 
                         </li>
-                        <li><a class="download-studio-btn" style="display: inline-block; font-weight: bold; background: #7A76FF; color: white !important; padding: 8px 16px; border-radius: 8px; text-decoration: none; transition: background 0.3s ease;" href="https://plotly.com/studio?utm_source=graphing_libraries&utm_medium=documentation&utm_campaign=studio_cloud_community&utm_content=header">Download Studio</a></li>
-                        <li><a style="font-weight: bold;" href="https://plotly.com/pricing?utm_source=graphing_libraries&utm_medium=documentation&utm_content=header">Studio and Cloud Pricing</a></li>
-                        <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing?utm_source=graphing_libraries&utm_medium=documentation&utm_content=header">Dash Enterprise Pricing</a></li>
+                        <li><a class="download-studio-btn" style="display: inline-block; font-weight: bold; background: #7A76FF; color: white !important; padding: 8px 16px; border-radius: 8px; text-decoration: none; transition: background 0.3s ease;" href="https://plotly.com/studio?source=graphing_libraries&medium=documentation&campaign=studio_cloud_community&content=header">Download Studio</a></li>
+                        <li><a style="font-weight: bold;" href="https://plotly.com/pricing?source=graphing_libraries&medium=documentation&content=header">Studio and Cloud Pricing</a></li>
+                        <li><a style="font-weight: bold;" href="https://plotly.com/get-pricing?source=graphing_libraries&medium=documentation&content=header">Dash Enterprise Pricing</a></li>
                         <!--<li><a style="font-weight: bold;" href="http://plotly.cloud">Dash Cloud</a></li>-->
 
                         {% if page.permalink contains "python/" %}

--- a/_includes/layouts/dashplug.html
+++ b/_includes/layouts/dashplug.html
@@ -1,5 +1,5 @@
 <div class="dash-plug">
-  <p>Plotly Studio: Transform any dataset into an interactive data application in minutes with AI. <a href="https://plotly.com/studio?utm_source=graphing_libraries&utm_medium=documentation&utm_campaign=studio_cloud_community&utm_content=sidebar">Try Plotly Studio now.</a>
+  <p>Plotly Studio: Transform any dataset into an interactive data application in minutes with AI. <a href="https://plotly.com/studio?source=graphing_libraries&medium=documentation&campaign=studio_cloud_community&content=sidebar">Try Plotly Studio now.</a>
   </p>
 </div>
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -68,12 +68,12 @@
 
         {% if page.permalink contains "python/" %}
 
-        <a href="https://plotly.com/studio?utm_source=graphing_libraries&utm_medium=documentation&utm_content=python_footer"><img width="100%" style="margin-top: 20px;"
+        <a href="https://plotly.com/studio?source=graphing_libraries&medium=documentation&content=python_footer"><img width="100%" style="margin-top: 20px;"
             src="/all_static/images/plotly-studio.png" /></a>
 
         {%elsif page.permalink contains "javascript/" %}
 
-        <a href="https://plotly.com/studio?utm_source=graphing_libraries&utm_medium=documentation&utm_content=javascript_footer"><img width="100%" style="margin-top: 20px;"
+        <a href="https://plotly.com/studio?source=graphing_libraries&medium=documentation&content=javascript_footer"><img width="100%" style="margin-top: 20px;"
             src="/all_static/images/plotly-studio.png" /></a>
 
         {% endif %}

--- a/_layouts/langindex.html
+++ b/_layouts/langindex.html
@@ -23,12 +23,12 @@
                 {% unless page.permalink contains "/reference/" %}
                 {% if page.permalink contains "python/" %}
 
-                <a href="https://plotly.com/studio?utm_source=graphing_libraries&utm_medium=documentation&utm_content=python_footer"><img width="100%" style="margin-top: 20px;"
+                <a href="https://plotly.com/studio?source=graphing_libraries&medium=documentation&content=python_footer"><img width="100%" style="margin-top: 20px;"
                         src="/all_static/images/plotly-studio.png" /></a>
 
                 {%elsif page.permalink contains "javascript/" %}
 
-                <a href="https://plotly.com/studio?utm_source=graphing_libraries&utm_medium=documentation&utm_content=javascript_footer"><img width="100%" style="margin-top: 20px;"
+                <a href="https://plotly.com/studio?source=graphing_libraries&medium=documentation&content=javascript_footer"><img width="100%" style="margin-top: 20px;"
                         src="/all_static/images/plotly-studio.png" /></a>
 
                 {% endif %}


### PR DESCRIPTION
Request from marketing. The presence of `utm_` was apparently overriding organic traffic data according to the SEO consultants.