### PR TITLE
Update Plotly logo href to marketing site

### DIFF
--- a/_includes/layouts/_header-main.html
+++ b/_includes/layouts/_header-main.html
@@ -18,9 +18,9 @@
         <div class="--wrap">
             <div class="--wrap-left">
                 <div class="-identity">
-                    <a href="{% if page.permalink contains 'python/' %}/python/{% else %}https://plotly.com/{% endif %}"><img src="/all_static/images/logo-black.svg"
+                    <a href="https://plotly.com/?source=graphing_libraries&medium=documentation&content=logo"><img src="/all_static/images/logo-black.svg"
                             style="height: 30px;" class="logo-dark"></a>
-                    <a href="{% if page.permalink contains 'python/' %}/python/{% else %}/graphing-libraries/{% endif %}"><img src="/all_static/images/logo-white.svg"
+                    <a href="https://plotly.com/?source=graphing_libraries&medium=documentation&content=logo"><img src="/all_static/images/logo-white.svg"
                             style="height: 30px;" class="logo-white"></a>
 
 


### PR DESCRIPTION
Request from marketing. They want the Plotly logo to go to plotly.com (with a fresh UTM) instead of the docs home page.