### PR TITLE
Add darwin25 to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,6 +322,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Modified automatically by my system, presumably to add lock support for later macOSes.