### PR TITLE
Use temporary sidebar ad during Marketo outage

### DIFF
--- a/_includes/layouts/webinar_plug.html
+++ b/_includes/layouts/webinar_plug.html
@@ -1,5 +1,5 @@
 
-   <a href="https://plotly.com/webinars/plotly-studio-embedded/?source=graphing_libraries&medium=documentation&campaign=plotly-studio-embedded-27aug2026&content=sidebar" target="_blank">
-     <img src="https://images.prismic.io/plotly-marketing-website-2/OrBL5FG-AQWYQ8n6_introducing-plotly-studio-embedded-docs.jpg?auto=format,compress"
-     style="width: 200px; height: 200px; position: fixed; bottom: 10px; left: 50px" alt="Sign up for the upcoming webinar: Introducing Plotly Studio Embedded">
+   <a href="https://plotly.com/examples/?source=graphing_libraries&medium=documentation&content=sidebar" target="_blank">
+     <img src="https://images.prismic.io/plotly-marketing-website-2/FxJv3krK6Ug95z8x_plotly-dash-examples-promo-graphic-for-dash-doc.jpg?auto=format,compress"
+     style="width: 200px; height: 200px; position: fixed; bottom: 10px; left: 50px" alt="Explore interactive dashboard examples and AI apps built by teams like yours">
    </a>


### PR DESCRIPTION
There's a Marketo outage and so none of the marketing forms work. Changing to a temporary ad while this gets resolved.